### PR TITLE
implement body section apiblueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,11 @@
-# The directory Mix will write compiled artifacts to.
 /_build/
-
-# If you run "mix test --cover", coverage assets end up here.
 /cover/
-
-# The directory Mix downloads your dependencies sources to.
 /deps/
-
-# Where third-party dependencies like ExDoc output generated docs.
 /doc/
-
-# Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
-
-# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-
-# Ignore package tarball (built via "mix hex.build").
 api_bluefy-*.tar
 
 # Visual Studio Code
-.elixir_ls/
+/.elixir_ls/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.0
-elixir 1.8.2
+erlang 21.1
+elixir 1.9.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.1
+erlang 21.1.1
 elixir 1.9.4

--- a/lib/api_blueprint/api_blueprint.ex
+++ b/lib/api_blueprint/api_blueprint.ex
@@ -86,7 +86,7 @@ defmodule Xcribe.ApiBlueprint do
   defp group_the_actions(resource_requests) do
     resource_requests
     |> Enum.map(fn {resource_name, reqs} ->
-      {resource_name, reqs |> Enum.group_by(&Formatter.resource_action(&1)) |> Enum.sort()}
+      {resource_name, reqs |> Enum.group_by(&Formatter.action_section(&1)) |> Enum.sort()}
     end)
   end
 

--- a/lib/api_blueprint/api_blueprint.ex
+++ b/lib/api_blueprint/api_blueprint.ex
@@ -74,7 +74,7 @@ defmodule Xcribe.ApiBlueprint do
   defp group_by_resource_name(requests) do
     requests
     |> Enum.map(fn {resource_group, reqs} ->
-      {resource_group, reqs |> Enum.group_by(&Formatter.resource(&1)) |> Enum.sort()}
+      {resource_group, reqs |> Enum.group_by(&Formatter.resource_section(&1)) |> Enum.sort()}
     end)
   end
 

--- a/lib/api_blueprint/api_blueprint.ex
+++ b/lib/api_blueprint/api_blueprint.ex
@@ -17,7 +17,7 @@ defmodule Xcribe.ApiBlueprint do
 
   def grouped_requests_to_string(requests) do
     requests
-    |> Enum.reduce(api_overview(), fn {group, reqs}, acc ->
+    |> Enum.reduce(api_metadata(), fn {group, reqs}, acc ->
       acc <> group <> resource_to_string(reqs)
     end)
   end
@@ -90,7 +90,7 @@ defmodule Xcribe.ApiBlueprint do
     end)
   end
 
-  defp api_overview, do: Formatter.overview(xcribe_info())
+  defp api_metadata, do: Formatter.metadata_section(xcribe_info())
 
   defp resource_description(%{controller: controller}),
     do: apply(Config.xcribe_information_source(), :resource_description, [controller])

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -12,10 +12,10 @@ defmodule Xcribe.ApiBlueprint.Formatter do
     )
   end
 
-  def resource(%Request{resource: resource, path: path}) do
+  def resource_section(%Request{resource: resource, path: path}) do
     apply_template(
       @resource_template,
-      resource_path: build_resource_path(path),
+      resource_path: build_uri_template(path),
       resource_name: prepare_and_captalize(resource)
     )
   end
@@ -159,7 +159,7 @@ defmodule Xcribe.ApiBlueprint.Formatter do
   defp add_header({header, value}, acc),
     do: apply_template(@header_item_template, header: header, value: value) <> acc
 
-  defp build_resource_path(path) do
+  defp build_uri_template(path) do
     path
     |> camelize_params()
     |> add_forward_slash()

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -47,10 +47,10 @@ defmodule Xcribe.ApiBlueprint.Formatter do
     )
   end
 
-  def response_description(%Request{status_code: code, resp_headers: headers}) do
+  def response_section(%Request{status_code: code, resp_headers: headers}) do
     apply_template(@response_template,
-      code: "#{code}",
-      content_type: find_content_type(headers)
+      code: to_string(code),
+      media_type: find_content_type(headers)
     )
   end
 
@@ -88,7 +88,7 @@ defmodule Xcribe.ApiBlueprint.Formatter do
       request_section(struct),
       request_headers(struct),
       request_attributes(struct, desc),
-      response_description(struct),
+      response_section(struct),
       response_headers(struct),
       response_body(struct)
     ])

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -20,7 +20,7 @@ defmodule Xcribe.ApiBlueprint.Formatter do
     )
   end
 
-  def resource_action(%Request{resource: resource, path: path, action: action, verb: verb}) do
+  def action_section(%Request{resource: resource, path: path, action: action, verb: verb}) do
     apply_template(
       @action_template,
       resource_name: prepare_and_captalize(resource),

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -5,6 +5,15 @@ defmodule Xcribe.ApiBlueprint.Formatter do
 
   use Xcribe.ApiBlueprint.Templates
 
+  def metadata_section(api_info) do
+    apply_template(
+      @metadata_template,
+      host: fetch_key(api_info, :host, ""),
+      name: fetch_key(api_info, :name, ""),
+      description: fetch_key(api_info, :description, "")
+    )
+  end
+
   def resource_group(%Request{} = request) do
     apply_template(
       @group_template,
@@ -26,15 +35,6 @@ defmodule Xcribe.ApiBlueprint.Formatter do
       resource_name: prepare_and_captalize(resource),
       action_name: remove_underline(action),
       resource_path: build_action_path(path, verb)
-    )
-  end
-
-  def overview(api_info) do
-    apply_template(
-      @overview_template,
-      host: fetch_key(api_info, :host, ""),
-      name: fetch_key(api_info, :name, ""),
-      description: fetch_key(api_info, :description, "")
     )
   end
 

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -88,6 +88,7 @@ defmodule Xcribe.ApiBlueprint.Formatter do
       request_section(struct),
       request_headers(struct),
       request_attributes(struct, desc),
+      request_body(struct),
       response_section(struct),
       response_headers(struct),
       response_body(struct)

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -144,10 +144,13 @@ defmodule Xcribe.ApiBlueprint.Formatter do
           param: camelize(" #{key}"),
           prefix: tab <> "+",
           type: type <> "#{type_of(value)}",
-          value: "#{remove_underline(value)}"
+          value: "#{item_value(value)}"
         )
     end)
   end
+
+  defp item_value(item) when is_list(item) or is_map(item), do: type_of(item)
+  defp item_value(item), do: remove_underline(item)
 
   defp get_description(param, desc),
     do: desc |> fetch_key(param, "The #{param}") |> remove_underline()

--- a/lib/api_blueprint/formatter.ex
+++ b/lib/api_blueprint/formatter.ex
@@ -39,11 +39,11 @@ defmodule Xcribe.ApiBlueprint.Formatter do
     )
   end
 
-  def request_description(%Request{description: description, header_params: headers}) do
+  def request_section(%Request{description: description, header_params: headers}) do
     apply_template(
       @request_template,
-      description: purge_string(description),
-      content_type: find_content_type(headers)
+      identifier: purge_string(description),
+      media_type: find_content_type(headers)
     )
   end
 
@@ -85,7 +85,7 @@ defmodule Xcribe.ApiBlueprint.Formatter do
 
   def full_request(%Request{} = struct, desc \\ %{}) do
     Enum.join([
-      request_description(struct),
+      request_section(struct),
       request_headers(struct),
       request_attributes(struct, desc),
       response_description(struct),

--- a/lib/api_blueprint/templates.ex
+++ b/lib/api_blueprint/templates.ex
@@ -9,11 +9,11 @@ defmodule Xcribe.ApiBlueprint.Templates do
       --description--
 
       """
-      @group_template "## Group --group_name--\n"
-      @resource_template "## --resource_name-- --resource_path--\n"
+      @group_template "## Group --identifier--\n"
+      @resource_template "## --identifier-- [--uri_template--]\n"
       @parameters_template "+ Parameters\n\n--parameters_list--\n"
       @item_template "--prefix----param--: `--value--` (--type--) - --description--\n"
-      @action_template "### --resource_name-- --action_name-- --resource_path--\n"
+      @action_template "### --identifier_resource-- --identifier_action-- [--request_method-- --uri_template--]\n"
       @attributes_template "    + Attributes\n\n--attributes_list--\n"
       @headers_template "    + Headers\n\n--headers--\n"
       @header_item_template "            --header--: --value--\n"

--- a/lib/api_blueprint/templates.ex
+++ b/lib/api_blueprint/templates.ex
@@ -18,7 +18,7 @@ defmodule Xcribe.ApiBlueprint.Templates do
       @headers_template "    + Headers\n\n--headers--\n"
       @header_item_template "            --header--: --value--\n"
       @request_template "+ Request --identifier-- (--media_type--)\n"
-      @response_template "+ Response --code-- (--content_type--)\n"
+      @response_template "+ Response --code-- (--media_type--)\n"
       @body_template "    + Body\n\n--body--\n"
     end
   end

--- a/lib/api_blueprint/templates.ex
+++ b/lib/api_blueprint/templates.ex
@@ -17,7 +17,7 @@ defmodule Xcribe.ApiBlueprint.Templates do
       @attributes_template "    + Attributes\n\n--attributes_list--\n"
       @headers_template "    + Headers\n\n--headers--\n"
       @header_item_template "            --header--: --value--\n"
-      @request_template "+ Request --description-- (--content_type--)\n"
+      @request_template "+ Request --identifier-- (--media_type--)\n"
       @response_template "+ Response --code-- (--content_type--)\n"
       @body_template "    + Body\n\n--body--\n"
     end

--- a/lib/api_blueprint/templates.ex
+++ b/lib/api_blueprint/templates.ex
@@ -1,7 +1,7 @@
 defmodule Xcribe.ApiBlueprint.Templates do
   defmacro __using__(_opts \\ []) do
     quote do
-      @overview_template """
+      @metadata_template """
       FORMAT: 1A
       HOST: --host--
 

--- a/lib/helpers/formatter.ex
+++ b/lib/helpers/formatter.ex
@@ -49,6 +49,8 @@ defmodule Xcribe.Helpers.Formatter do
   def type_of(item) when is_number(item), do: "number"
   def type_of(item) when is_binary(item), do: "string"
   def type_of(item) when is_boolean(item), do: "boolean"
+  def type_of(item) when is_map(item), do: "object"
+  def type_of(item) when is_list(item), do: "array"
 
   def purge_string(string),
     do: string |> String.replace(@non_word_regex, " ") |> String.replace(@mult_spaces_regex, " ")

--- a/test/lib/api_blueprint/api_blueprint_test.exs
+++ b/test/lib/api_blueprint/api_blueprint_test.exs
@@ -53,7 +53,7 @@ defmodule Xcribe.ApiBlueprintTest do
           action: "create",
           controller: Elixir.Xcribe.ProtocolsController,
           description: "create the protocol",
-          header_params: [{"authorization", "token"}],
+          header_params: [{"authorization", "token"}, {"content-type", "application/json"}],
           params: %{"name" => "zelda", "server_id" => 88, "priority" => 0},
           path: "server/{server_id}/protocols",
           path_params: %{"server_id" => 88},
@@ -88,7 +88,7 @@ defmodule Xcribe.ApiBlueprintTest do
                  + serverId: `88` (required, number) - The id number of the server
 
              ### Protocols create [POST server/{serverId}/protocols/]
-             + Request create the protocol (text/plain)
+             + Request create the protocol (application/json)
                  + Headers
 
                          authorization: token
@@ -98,6 +98,12 @@ defmodule Xcribe.ApiBlueprintTest do
                      + name: `zelda` (string) - The protocol full name
                      + priority: `0` (number) - the priority of the protocol. It could be 0 or 1
 
+                 + Body
+
+                         {
+                           "name": "zelda",
+                           "priority": 0
+                         }
              + Response 201 (application/json)
                  + Body
 

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -101,11 +101,11 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
     end
   end
 
-  describe "resource_action/1" do
+  describe "action_section/1" do
     test "return formatted resource action" do
       struct = %Request{resource: "users", path: "/users", action: "index", verb: "get"}
 
-      assert Formatter.resource_action(struct) == "### Users index [GET /users/]\n"
+      assert Formatter.action_section(struct) == "### Users index [GET /users/]\n"
     end
 
     test "when there is an arg in the path's end" do
@@ -116,14 +116,14 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         verb: "put"
       }
 
-      assert Formatter.resource_action(struct) ==
+      assert Formatter.action_section(struct) ==
                "### Users Posts update [PUT /users/{id}/posts/{post_id}/]\n"
     end
 
     test "when there is underline" do
       struct = %Request{resource: "users_posts", path: "/users", action: "new_index", verb: "get"}
 
-      assert Formatter.resource_action(struct) == "### Users Posts new index [GET /users/]\n"
+      assert Formatter.action_section(struct) == "### Users Posts new index [GET /users/]\n"
     end
 
     test "camelize params" do
@@ -134,7 +134,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         verb: "get"
       }
 
-      assert Formatter.resource_action(struct) ==
+      assert Formatter.action_section(struct) ==
                "### Users Posts new index [GET /users/{userId}/user/]\n"
     end
   end

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -464,7 +464,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
     end
   end
 
-  describe "overview/1" do
+  describe "metadata_section/1" do
     test "return API overview" do
       api_info = %{
         description: "some cool description",
@@ -472,7 +472,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         name: "The Cool API"
       }
 
-      assert Formatter.overview(api_info) == """
+      assert Formatter.metadata_section(api_info) == """
              FORMAT: 1A
              HOST: http://my-host.com
 

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -340,6 +340,22 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
              """
     end
 
+    test "attribute object and array" do
+      struct = %Request{
+        request_body: %{"age" => ["item one", "item two"], "name" => %{"key" => "value"}}
+      }
+
+      descriptions = %{"age" => "the user age", "name" => "is the full_name of the user"}
+
+      assert Formatter.request_attributes(struct, descriptions) == """
+                 + Attributes
+
+                     + age: `array` (array) - the user age
+                     + name: `object` (object) - is the full name of the user
+
+             """
+    end
+
     test "return empty string when no body" do
       struct = %Request{
         request_body: %{}

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -349,13 +349,13 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
     end
   end
 
-  describe "response_description/1" do
+  describe "response_section/1" do
     test "return formatted response description" do
       struct = %Request{
         status_code: 201
       }
 
-      assert Formatter.response_description(struct) == "+ Response 201 (text/plain)\n"
+      assert Formatter.response_section(struct) == "+ Response 201 (text/plain)\n"
     end
 
     test "when has content type header" do
@@ -366,7 +366,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         ]
       }
 
-      assert Formatter.response_description(struct) == "+ Response 201 (multipart/mixed)\n"
+      assert Formatter.response_section(struct) == "+ Response 201 (multipart/mixed)\n"
     end
   end
 

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -200,18 +200,18 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
     end
   end
 
-  describe "request_description/1" do
+  describe "request_section/1" do
     test "return formatted request description" do
       struct = %Request{description: "create user with token"}
 
-      assert Formatter.request_description(struct) ==
+      assert Formatter.request_section(struct) ==
                "+ Request create user with token (text/plain)\n"
     end
 
     test "clean description" do
       struct = %Request{description: "POST /api/boletos [ create  ] add a boleto"}
 
-      assert Formatter.request_description(struct) ==
+      assert Formatter.request_section(struct) ==
                "+ Request POST api boletos create add a boleto (text/plain)\n"
     end
 
@@ -224,7 +224,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         ]
       }
 
-      assert Formatter.request_description(struct) ==
+      assert Formatter.request_section(struct) ==
                "+ Request create user with token (application/json; charset=utf-8)\n"
     end
   end

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -489,7 +489,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         description: "create an user",
         header_params: [
           {"authorization", "token"},
-          {"content-type", "multipart/mixed; boundary=plug_conn_test"}
+          {"content-type", "application/json"}
         ],
         params: %{"age" => 5, "name" => "teste"},
         request_body: %{"age" => 5, "name" => "teste"},
@@ -502,7 +502,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
       }
 
       assert Formatter.full_request(struct) == """
-             + Request create an user (multipart/mixed; boundary=plug_conn_test)
+             + Request create an user (application/json)
                  + Headers
 
                          authorization: token
@@ -512,6 +512,12 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
                      + age: `5` (number) - The age
                      + name: `teste` (string) - The name
 
+                 + Body
+
+                         {
+                           "age": 5,
+                           "name": "teste"
+                         }
              + Response 201 (application/json; charset=utf-8)
                  + Headers
 
@@ -531,7 +537,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
         description: "create an user",
         header_params: [
           {"authorization", "token"},
-          {"content-type", "multipart/mixed; boundary=plug_conn_test"}
+          {"content-type", "application/json"}
         ],
         params: %{"age" => 5, "name" => "teste"},
         request_body: %{"age" => 5, "name" => "teste"},
@@ -546,7 +552,7 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
       descriptions = %{"age" => "the user age", "name" => "is the full name of the user"}
 
       assert Formatter.full_request(struct, descriptions) == """
-             + Request create an user (multipart/mixed; boundary=plug_conn_test)
+             + Request create an user (application/json)
                  + Headers
 
                          authorization: token
@@ -556,6 +562,12 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
                      + age: `5` (number) - the user age
                      + name: `teste` (string) - is the full name of the user
 
+                 + Body
+
+                         {
+                           "age": 5,
+                           "name": "teste"
+                         }
              + Response 201 (application/json; charset=utf-8)
                  + Headers
 

--- a/test/lib/api_blueprint/formatter_test.exs
+++ b/test/lib/api_blueprint/formatter_test.exs
@@ -18,35 +18,35 @@ defmodule Xcribe.ApiBlueprint.FormatterTest do
     end
   end
 
-  describe "resource/1" do
+  describe "resource_section/1" do
     test "return formatted resource" do
       struct = %Request{resource: "users", path: "/users"}
 
-      assert Formatter.resource(struct) == "## Users [/users/]\n"
+      assert Formatter.resource_section(struct) == "## Users [/users/]\n"
     end
 
     test "when path ends with forward slash" do
       struct = %Request{resource: "users", path: "/users/"}
 
-      assert Formatter.resource(struct) == "## Users [/users/]\n"
+      assert Formatter.resource_section(struct) == "## Users [/users/]\n"
     end
 
     test "when there is an arg in the path's end" do
       struct = %Request{resource: "users posts", path: "/users/{id}/posts/{post_id}"}
 
-      assert Formatter.resource(struct) == "## Users Posts [/users/{id}/posts/]\n"
+      assert Formatter.resource_section(struct) == "## Users Posts [/users/{id}/posts/]\n"
     end
 
     test "resource with underline" do
       struct = %Request{resource: "users_posts", path: "/users/{id}/posts/{post_id}"}
 
-      assert Formatter.resource(struct) == "## Users Posts [/users/{id}/posts/]\n"
+      assert Formatter.resource_section(struct) == "## Users Posts [/users/{id}/posts/]\n"
     end
 
     test "camelize params" do
       struct = %Request{resource: "users", path: "/users/{user_id}/posts/{post_id}"}
 
-      assert Formatter.resource(struct) == "## Users [/users/{userId}/posts/]\n"
+      assert Formatter.resource_section(struct) == "## Users [/users/{userId}/posts/]\n"
     end
   end
 

--- a/test/lib/helpers/document_test.exs
+++ b/test/lib/helpers/document_test.exs
@@ -1,5 +1,5 @@
 defmodule Xcribe.Helpers.DocumentTest do
-  use Xcribe.ConnCase, async: true
+  use Xcribe.ConnCase, async: false
 
   alias Xcribe.{ConnParser, Recorder}
 

--- a/test/support/api_blueprint_examples.ex
+++ b/test/support/api_blueprint_examples.ex
@@ -42,7 +42,7 @@ defmodule Xcribe.ApiBlueprintExamples do
                    description: "create an user",
                    header_params: [
                      {"authorization", "token"},
-                     {"content-type", "multipart/mixed; boundary=plug_conn_test"}
+                     {"content-type", "application/json; boundary=plug_conn_test"}
                    ],
                    params: %{"age" => 5, "name" => "teste"},
                    path: "/users",
@@ -151,7 +151,7 @@ defmodule Xcribe.ApiBlueprintExamples do
                   }
       ## Users [/users/]
       ### Users create [POST /users/]
-      + Request create an user (multipart/mixed; boundary=plug_conn_test)
+      + Request create an user (application/json; boundary=plug_conn_test)
           + Headers
 
                   authorization: token
@@ -161,6 +161,12 @@ defmodule Xcribe.ApiBlueprintExamples do
               + age: `5` (number) - The age
               + name: `teste` (string) - The name
 
+          + Body
+
+                  {
+                    "age": 5,
+                    "name": "teste"
+                  }
       + Response 201 (application/json; charset=utf-8)
           + Headers
 

--- a/test/support/controllers/notes_controller.ex
+++ b/test/support/controllers/notes_controller.ex
@@ -1,7 +1,7 @@
 defmodule Xcribe.NotesController do
   use Phoenix.Controller, namespace: Xcribe
 
-  def index(conn, params) do
+  def index(conn, _params) do
     conn
     |> put_status(:ok)
     |> json([])

--- a/test/support/requests_examples.ex
+++ b/test/support/requests_examples.ex
@@ -30,7 +30,7 @@ defmodule Xcribe.RequestsExamples do
           description: "create an user",
           header_params: [
             {"authorization", "token"},
-            {"content-type", "multipart/mixed; boundary=plug_conn_test"}
+            {"content-type", "application/json; boundary=plug_conn_test"}
           ],
           params: %{"age" => 5, "name" => "teste"},
           path: "/users",
@@ -86,7 +86,119 @@ defmodule Xcribe.RequestsExamples do
           status_code: 200,
           verb: "get"
         }
-      ]
+        ]
+
+      @grouped_sample_requests [
+        {"## Group API\n",
+          [
+           {"## Users Posts [/users/{usersId}/posts/]\n",
+             [
+              {"### Users Posts show [GET /users/{usersId}/posts/{id}/]\n",
+                [
+                  %Request{
+                    action: "show",
+                    controller: Elixir.Xcribe.PostsController,
+                    description: "get all user posts",
+                    header_params: [{"authorization", "token"}],
+                    params: %{"users_id" => "1"},
+                    path: "/users/{users_id}/posts/{id}",
+                    path_params: %{"users_id" => "1", "id" => "2"},
+                    query_params: %{},
+                    request_body: %{},
+                    resource: "users_posts",
+                    resource_group: :api,
+                    resp_body: "{\"id\":1,\"title\":\"user 1\"}",
+                    resp_headers: [
+                      {"content-type", "application/json; charset=utf-8"},
+                      {"cache-control", "max-age=0, private, must-revalidate"}
+                    ],
+                    status_code: 200,
+                    verb: "get"
+                  }
+                ]}
+             ]},
+           {"## Users [/users/]\n",
+             [
+              {"### Users create [POST /users/]\n",
+                [
+                  %Request{
+                    action: "create",
+                    controller: Elixir.Xcribe.UsersController,
+                    description: "create an user",
+                    header_params: [
+                      {"authorization", "token"},
+                      {"content-type", "application/json; boundary=plug_conn_test"}
+                    ],
+                    params: %{"age" => 5, "name" => "teste"},
+                    path: "/users",
+                    path_params: %{},
+                    query_params: %{},
+                    request_body: %{"age" => 5, "name" => "teste"},
+                    resource: "users",
+                    resource_group: :api,
+                    resp_body: "{\"age\":5,\"name\":\"teste\"}",
+                    resp_headers: [
+                      {"content-type", "application/json; charset=utf-8"},
+                      {"cache-control", "max-age=0, private, must-revalidate"}
+                    ],
+                    status_code: 201,
+                    verb: "post"
+                  }
+                ]},
+              {"### Users index [GET /users/]\n",
+                [
+                  %Request{
+                    action: "index",
+                    controller: Elixir.Xcribe.UsersController,
+                    description: "get all users",
+                    header_params: [{"authorization", "token"}],
+                    params: %{},
+                    path: "/users",
+                    path_params: %{},
+                    query_params: %{},
+                    request_body: %{},
+                    resource: "users",
+                    resource_group: :api,
+                    resp_body: "[{\"id\":1,\"name\":\"user 1\"},{\"id\":2,\"name\":\"user 2\"}]",
+                    resp_headers: [
+                      {"content-type", "application/json; charset=utf-8"},
+                      {"cache-control", "max-age=0, private, must-revalidate"}
+                    ],
+                    status_code: 200,
+                    verb: "get"
+                  }
+                ]}
+              ]}
+           ]},
+        {"## Group MONITORING\n",
+          [
+           {"## Monitoring [/monitoring/]\n",
+             [
+              {"### Monitoring index [GET /monitoring/]\n",
+                [
+                  %Request{
+                    action: "index",
+                    controller: Elixir.Xcribe.MonitoringController,
+                    description: "get monitoring info",
+                    header_params: [{"authorization", "token"}],
+                    params: %{},
+                    path: "/monitoring/",
+                    path_params: %{},
+                    query_params: %{},
+                    request_body: %{},
+                    resource: "monitoring",
+                    resource_group: :monitoring,
+                    resp_body: "[{\"status\":\"ok\"}]",
+                    resp_headers: [
+                      {"content-type", "application/json; charset=utf-8"}
+                    ],
+                    status_code: 200,
+                    verb: "get"
+                  }
+                ]}
+             ]}
+          ]}
+        ]
     end
   end
 end


### PR DESCRIPTION
As described in #4 return the body section on ApiBlueprint formatter.

Some methods names was improved to the same semantic  used at ApiBlueprint specification.