### PR TITLE
Fix parsing halted connection

### DIFF
--- a/lib/conn_parser.ex
+++ b/lib/conn_parser.ex
@@ -2,14 +2,21 @@ defmodule Xcribe.ConnParser do
   alias Xcribe.{Config, Request}
 
   def execute(conn, description \\ "sample request") do
-    route = identify_route(conn)
-    path = format_path(route.path, Map.keys(conn.path_params))
+    conn
+    |> identify_route()
+    |> parse_conn(conn, description)
+  end
+
+  defp parse_conn({:error, _} = error, _conn, _description), do: error
+
+  defp parse_conn(route, conn, description) do
+    path = format_path(route.route, Map.keys(conn.path_params))
     namespaces = fetch_namespaces()
 
     %Request{
       action: route |> router_options() |> Atom.to_string(),
       header_params: conn.req_headers,
-      controller: conn |> controller_module(),
+      controller: controller_module(route),
       description: description,
       params: conn.params,
       path: path,
@@ -21,42 +28,28 @@ defmodule Xcribe.ConnParser do
       resp_body: conn.resp_body,
       resp_headers: conn.resp_headers,
       status_code: conn.status,
-      verb: Atom.to_string(route.verb)
+      verb: String.downcase(conn.method)
     }
   end
 
-  defp identify_route(conn) do
+  defp identify_route(%{method: method, host: host, path_info: path} = conn) do
     conn
-    |> router_module()
-    |> apply(:__routes__, [])
-    |> enum_find(conn)
+    |> router_module
+    |> apply(:__match_route__, [method, decode_uri(path), host])
+    |> extract_route_info()
   end
 
-  defp enum_find(routes, conn) do
-    routes
-    |> Enum.find(fn route -> has_eql_values?(route, conn) end)
-  end
+  defp router_module(%{private: %{phoenix_router: router}}), do: router
 
-  defp has_eql_values?(route, conn) do
-    route.plug == controller_module(conn) and router_options(route) == action_atom(conn) and
-      route.verb == verb_atom(conn) and match_path?(route, conn)
-  end
+  defp decode_uri(path_info), do: Enum.map(path_info, &URI.decode/1)
+
+  defp extract_route_info({%{} = route_info, _, _, _}), do: route_info
+  defp extract_route_info(_), do: {:error, "route not found"}
 
   defp router_options(%{plug_opts: opts}), do: opts
   defp router_options(%{opts: opts}), do: opts
 
-  defp match_path?(%{path: route_path}, %{request_path: conn_path}),
-    do: Regex.match?(regex_to(route_path), conn_path)
-
-  defp regex_to(path), do: ~r/#{replace_params(path)}/
-
-  defp replace_params(path), do: String.replace(path, ~r/\:\w+/, ".*")
-
-  defp router_module(%{private: %{phoenix_router: router}}), do: router
-
-  defp controller_module(%{private: %{phoenix_controller: controller}}), do: controller
-
-  defp action_atom(%{private: %{phoenix_action: action}}), do: action
+  defp controller_module(%{plug: controller}), do: controller
 
   defp resource_group(%{pipe_through: [head | _rest]}), do: head
 
@@ -69,8 +62,6 @@ defmodule Xcribe.ConnParser do
   end
 
   defp remove_namespace(namespace, path), do: String.replace(path, ~r/^#{namespace}/, "")
-
-  defp verb_atom(%{method: verb}), do: verb |> String.downcase() |> String.to_atom()
 
   defp format_path(path, params), do: Enum.reduce(params, path, &transform_param/2)
 

--- a/lib/conn_parser.ex
+++ b/lib/conn_parser.ex
@@ -36,7 +36,7 @@ defmodule Xcribe.ConnParser do
   defp parse_conn({:error, _} = error, _conn, _description), do: error
 
   defp parse_conn(route, conn, description) do
-    path = format_path(route.route, Map.keys(conn.path_params))
+    path = format_path(route.route, conn.path_params)
 
     %Request{
       action: route |> router_options() |> Atom.to_string(),
@@ -68,7 +68,9 @@ defmodule Xcribe.ConnParser do
 
   defp decode_uri(path_info), do: Enum.map(path_info, &URI.decode/1)
 
-  defp extract_route_info({%{} = route_info, _, _, _}), do: route_info
+  defp extract_route_info({%{} = route_info, _callback_one, _callback_two, _plug_info}),
+    do: route_info
+
   defp extract_route_info(_), do: {:error, "route not found"}
 
   defp router_options(%{plug_opts: opts}), do: opts
@@ -88,7 +90,8 @@ defmodule Xcribe.ConnParser do
 
   defp remove_namespace(namespace, path), do: String.replace(path, ~r/^#{namespace}/, "")
 
-  defp format_path(path, params), do: Enum.reduce(params, path, &transform_param/2)
+  defp format_path(path, params),
+    do: params |> Map.keys() |> Enum.reduce(path, &transform_param/2)
 
   defp transform_param(param, path), do: String.replace(path, ":#{param}", "{#{param}}")
 

--- a/lib/conn_parser.ex
+++ b/lib/conn_parser.ex
@@ -59,7 +59,7 @@ defmodule Xcribe.ConnParser do
 
   defp identify_route(%{method: method, host: host, path_info: path} = conn) do
     conn
-    |> router_module
+    |> router_module()
     |> apply(:__match_route__, [method, decode_uri(path), host])
     |> extract_route_info()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Xcribe.MixProject do
       app: :xcribe,
       version: @version,
       name: "XCribe",
+      docs: docs(),
       description: @description,
       elixir: "~> 1.8",
       package: package(),
@@ -58,6 +59,36 @@ defmodule Xcribe.MixProject do
     [
       licenses: ["Apache-2.0"],
       links: @links
+    ]
+  end
+
+  defp docs do
+    [
+      source_ref: "v#{@version}",
+      main: "readme",
+      extras: [
+        "README.md": [title: "README"]
+      ],
+      groups_for_modules: doc_groups_for_modules()
+    ]
+  end
+
+  defp doc_groups_for_modules do
+    [
+      BluePrint: [
+        Xcribe.ApiBlueprint,
+        Xcribe.ApiBlueprint.Formatter,
+        Xcribe.ApiBlueprint.Templates
+      ],
+      Swagger: [
+        Xcribe.Swagger,
+        Xcribe.Swagger.Descriptor,
+        Xcribe.Swagger.Formatter
+      ],
+      Helpers: [
+        Xcribe.Helpers.Document,
+        Xcribe.Helpers.Formatter
+      ]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/danielwsx64/xcribe"}
 

--- a/test/lib/conn_parser_test.exs
+++ b/test/lib/conn_parser_test.exs
@@ -14,7 +14,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "index",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{},
                path: "/users",
@@ -72,7 +72,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Xcribe.Request{
                action: "cancel",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{"users_id" => "1"},
                path: "/users/{users_id}/cancel",
@@ -99,7 +99,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "show",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{"id" => "1"},
                path: "/users/{id}",
@@ -127,7 +127,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "create",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -158,7 +158,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "update",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -189,7 +189,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "update",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -220,7 +220,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "delete",
                controller: Elixir.Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{"id" => "1"},
                path: "/users/{id}",
@@ -245,7 +245,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "index",
                controller: Elixir.Xcribe.PostsController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{"users_id" => "1"},
                path: "/users/{users_id}/posts",
@@ -273,7 +273,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "create",
                controller: Elixir.Xcribe.PostsController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -304,7 +304,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "update",
                controller: Elixir.Xcribe.PostsController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -335,7 +335,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "update",
                controller: Elixir.Xcribe.PostsController,
-               description: "sample request",
+               description: "",
                header_params: [
                  {"authorization", "token"},
                  {"content-type", "multipart/mixed; boundary=plug_conn_test"}
@@ -372,7 +372,7 @@ defmodule Xcribe.ConnParserTest do
       assert ConnParser.execute(conn) == %Request{
                action: "index",
                controller: Xcribe.UsersController,
-               description: "sample request",
+               description: "",
                header_params: [{"authorization", "token"}],
                params: %{},
                path: "/authenticated/users",

--- a/test/lib/conn_parser_test.exs
+++ b/test/lib/conn_parser_test.exs
@@ -1,6 +1,7 @@
 defmodule Xcribe.ConnParserTest do
   use Xcribe.ConnCase, async: true
 
+  alias Plug.Conn
   alias Xcribe.{ConnParser, Request}
 
   describe "parse/1" do
@@ -362,64 +363,45 @@ defmodule Xcribe.ConnParserTest do
       assert %Request{resource: "notes"} = ConnParser.execute(conn)
     end
 
-    test "test group subject" do
-      _incomplete_conn = %{
-        adapter:
-          {Plug.Adapters.Test.Conn,
-           %{
-             chunks: nil,
-             http_protocol: :"HTTP/1.1",
-             method: "POST",
-             owner: "",
-             params: %{},
-             peer_data: %{address: {127, 0, 0, 1}, port: 111_317, ssl_cert: nil},
-             ref: "",
-             req_body: "--plug_conn_test--"
-           }},
-        assigns: %{},
-        before_send: [],
-        body_params: %{},
-        cookies: %Plug.Conn.Unfetched{aspect: :cookies},
-        halted: true,
+    test "conn is halted before match route", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "token")
+        |> get(authenticated_users_path(conn, :index))
+
+      assert ConnParser.execute(conn) == %Request{
+               action: "index",
+               controller: Xcribe.UsersController,
+               description: "sample request",
+               header_params: [{"authorization", "token"}],
+               params: %{},
+               path: "/authenticated/users",
+               path_params: %{},
+               query_params: %{},
+               request_body: %{},
+               resource: "authenticated_users",
+               resource_group: :authenticated,
+               resp_body: "{\"message\":\"not authorized\"}",
+               resp_headers: [
+                 {"content-type", "application/json; charset=utf-8"},
+                 {"cache-control", "max-age=0, private, must-revalidate"}
+               ],
+               status_code: 401,
+               verb: "get"
+             }
+    end
+
+    test "not found route" do
+      conn = %Conn{
         host: "www.example.com",
-        method: "POST",
-        owner: "",
-        params: %{},
-        path_info: ["api", "cards"],
-        path_params: %{},
-        peer: {{127, 0, 0, 1}, 111_317},
-        port: 80,
+        method: "GET",
+        path_info: ["invalipath"],
         private: %{
-          Xcribe.WebRouter => {[], %{}},
-          :phoenix_endpoint => Xcribe.Endpoint,
-          :phoenix_format => "json",
-          :phoenix_pipelines => [:restrict_api],
-          :phoenix_recycled => false,
-          :phoenix_router => Xcribe.WebRouter,
-          :plug_session_fetch => "",
-          :plug_skip_csrf_protection => true
-        },
-        query_params: %{},
-        query_string: "",
-        remote_ip: {127, 0, 0, 1},
-        req_cookies: %Plug.Conn.Unfetched{aspect: :cookies},
-        req_headers: [{"content-type", "application/json"}],
-        request_path: "/api/cards",
-        resp_body: "{\"error\":\"not authorized\"}",
-        resp_cookies: %{},
-        resp_headers: [
-          {"cache-control", "max-age=0, private, must-revalidate"},
-          {"content-type", "application/json; charset=utf-8"}
-        ],
-        scheme: :http,
-        script_name: [],
-        secret_key_base: "",
-        state: :sent,
-        status: 401
+          :phoenix_router => Xcribe.WebRouter
+        }
       }
 
-      assert 1 == 1
-      # TODO: fix this issue. The proble is i cant determine the route
+      assert ConnParser.execute(conn) == {:error, "route not found"}
     end
   end
 end

--- a/test/support/plugs/authentication.ex
+++ b/test/support/plugs/authentication.ex
@@ -1,0 +1,14 @@
+defmodule Xcribe.Plugs.Authentication do
+  import Plug.Conn
+
+  use Phoenix.Controller, namespace: Xcribe
+
+  def init(_opts), do: []
+
+  def call(conn, _opts) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{message: "not authorized"})
+    |> halt()
+  end
+end

--- a/test/support/web_router.ex
+++ b/test/support/web_router.ex
@@ -7,10 +7,21 @@ defmodule Xcribe.WebRouter do
     plug(:accepts, ["json"])
   end
 
+  pipeline :authenticated do
+    plug(:api)
+    plug(Xcribe.Plugs.Authentication)
+  end
+
   scope "/namespace_ignored", Xcribe do
     pipe_through(:api)
 
     resources("/notes", NotesController, only: [:index])
+  end
+
+  scope "/authenticated", Xcribe, as: :authenticated do
+    pipe_through(:authenticated)
+
+    resources("/users", UsersController)
   end
 
   scope "/", Xcribe do


### PR DESCRIPTION
### Motivation
When a Plug halt the connection before it be dispatched to a controller the `Xcribe.ConnParser` can't extract needed information about the application route that match the connection.  Currently when this happens a `FunctionClauseError` excepiton is raised.

### Proposed Solution
Change the way the route information is got.

Obs: additionally as added some documentation about `ConnParser` and include some doc configuration to `mix.exs`.