### PR TITLE
Fix/broken vnd content type

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -51,7 +51,7 @@
         #
         ## Consistency Checks
         #
-        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.ExceptionNames, false},
         {Credo.Check.Consistency.LineEndings, []},
         {Credo.Check.Consistency.ParameterPatternMatching, []},
         {Credo.Check.Consistency.SpaceAroundOperators, []},

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.2"}
+    {:xcribe, "~> 0.3"}
   ]
 end
 ```
@@ -142,15 +142,17 @@ If Swagger format is configured, [Swagger UI](https://swagger.io/tools/swagger-u
 You can add this configurations to your `config/test.ex`
 
 -   information_source: the module with doc information
--   output_file: a custom name to the output file
--   doc_format: ApiBlueprint or Swagger formats
+-   output: a custom name to the output file
+-   format: ApiBlueprint or Swagger formats
 -   env_var: a custom name to the env to active XCribe.Formatter
 
 Example
 
 ```elixir
-config :xcribe, :information_source, YourAppWeb.Information
-config :xcribe, :output_file, "API-DOCUMENTATION.apib"
-config :xcribe, :doc_format, :swagger # or :api_blueprint
-config :xcribe, :env_var, "DOC_API"
+config :xcribe, :configuration, [
+  information_source: YourAppWeb.Information,
+  output: "API-DOCUMENTATION.apib",
+  format: :swagger # or :api_blueprint,
+  env_var: "DOC_API"
+]
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Hex.pm](https://img.shields.io/hexpm/v/xcribe?style=flat-square)
+![Hex.pm](https://img.shields.io/hexpm/l/xcribe?style=flat-square)
+![Hex.pm](https://img.shields.io/hexpm/dt/xcribe?style=flat-square)
+
 # XCribe
 
 XCribe is a doc generator for Rest APIs built with Phoenix.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ You can add this configurations to your `config/test.ex`
 -   output: a custom name to the output file
 -   format: ApiBlueprint or Swagger formats
 -   env_var: a custom name to the env to active XCribe.Formatter
--   json_library: The library to be used for json decode/encode
+-   json_library: The library to be used for json decode/encode. See `Xcribe.JSON`
 
 Example
 
 ```elixir
-config :xcribe, :configuration, [
+config :xcribe, [
   information_source: YourAppWeb.Information,
   output: "API-DOCUMENTATION.apib",
   format: :swagger # or :api_blueprint,

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can add this configurations to your `config/test.ex`
 -   output: a custom name to the output file
 -   format: ApiBlueprint or Swagger formats
 -   env_var: a custom name to the env to active XCribe.Formatter
+-   json_library: The library to be used for json decode/encode
 
 Example
 
@@ -153,6 +154,7 @@ config :xcribe, :configuration, [
   information_source: YourAppWeb.Information,
   output: "API-DOCUMENTATION.apib",
   format: :swagger # or :api_blueprint,
-  env_var: "DOC_API"
+  env_var: "DOC_API",
+  json_library: Jason
 ]
 ```

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,4 @@
 use Mix.Config
 
-config :xcribe, :information_source, Xcribe.Support.Information
-
 # Support Config
 import_config "test_support.exs"

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "skip_files": [
+    "test/support"
+  ]
+}

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,28 +1,119 @@
 defmodule Xcribe.Config do
-  @valid_formats [:api_blueprint, :swagger]
-  def output_file, do: Application.get_env(:xcribe, :output_file, default_output_file())
+  @moduledoc """
+  Handle Xcribe configurations.
 
+  You must configure Xcribe in your test config file `config/test.exs` as:
+      config: xcribe, :configuration, [
+        information_source: YourApp.YouModuleInformation,
+        format: :swagger,
+        output: "app_doc.json",
+        env_var: "CI_ENV_FOR_DOC"
+      ]
+
+
+  ### Available configurations:
+    * `:information_source` - Module that implements `Xcribe.Information` with
+    API information.
+    * `:output` - The name of file output with generated configuration.
+    * `:format` - Format to generate documentation, allowed :api_blueprint and
+    :swagger.
+    * `:env_var` - Environment variable name for active Xcribe documentation
+    generator.
+  """
+
+  alias Xcribe.UnknownFormat
+
+  @valid_formats [:api_blueprint, :swagger]
+
+  @doc """
+  Return the file name to output generated documentation.
+
+  If no config was given the default names are `api_doc.apib` for Blueprint
+  format and `openapi.json` for Swagger format.
+
+  To configure output name:
+
+      config :xcribe, [
+        output: "custom_name.json"
+      ]
+  """
+  def output_file, do: get_xcribe_config(:output, default_output_file())
+
+  @doc """
+  Return the format for documentation.
+
+  Default is `:api_blueprint`. If an invalid format is given an exception will
+  raise.
+
+  To configure the documentation format:
+
+      config :xcribe, [
+        format: :swagger
+      ]
+  """
   def doc_format do
-    :xcribe
-    |> Application.get_env(:doc_format, :api_blueprint)
+    :format
+    |> get_xcribe_config(:api_blueprint)
     |> validate_doc_format()
   end
 
+  @doc """
+  Return if Xcribe should document the specs.
+
+  It's determined by an env var `XCRIBE_ENV`. Don't matter the var content if
+  it's defined Xcribe will generate documentation.
+
+  The env var name can changed by configuration:
+
+      config :xcribe, [
+        env_var: "CUSTOM_ENV_NAME"
+      ]
+  """
   def active?, do: !is_nil(System.get_env(env_var_name()))
 
+  @doc """
+  Return the iformation module with API information (`Xcribe.Information`).
+
+  If information source is not given an excpiton will raise.
+
+  To configure the source:
+
+      config :xcribe, [
+        information_source: YourApp.YouModuleInformation
+      ]
+  """
   def xcribe_information_source,
     do: Application.fetch_env!(:xcribe, :information_source)
 
-  defp env_var_name, do: Application.get_env(:xcribe, :env_var, "XCRIBE_ENV")
+  defp env_var_name, do: get_xcribe_config(:env_var, "XCRIBE_ENV")
 
   defp default_output_file do
     case doc_format() do
       :api_blueprint -> "api_doc.apib"
       :swagger -> "openapi.json"
-      _ -> ""
     end
   end
 
   defp validate_doc_format(format) when format in @valid_formats, do: format
-  defp validate_doc_format(_), do: :error
+  defp validate_doc_format(format), do: raise(UnknownFormat, format)
+
+  defp get_xcribe_config(key, default) do
+    cond do
+      value = new_config(key) -> value
+      value = old_config(key) -> value
+      true -> default
+    end
+  end
+
+  defp new_config(key) do
+    :xcribe
+    |> Application.get_env(:configuration, [])
+    |> Keyword.get(key)
+  end
+
+  defp old_config(key), do: Application.get_env(:xcribe, rename_key(key))
+
+  defp rename_key(:output), do: :output_file
+  defp rename_key(:format), do: :doc_format
+  defp rename_key(key), do: key
 end

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -3,7 +3,8 @@ defmodule Xcribe.Config do
   Handle Xcribe configurations.
 
   You must configure Xcribe in your test config file `config/test.exs` as:
-      config :xcribe, :configuration, [
+
+      config: xcribe, [
         information_source: YourApp.YouModuleInformation,
         format: :swagger,
         output: "app_doc.json",
@@ -40,7 +41,7 @@ defmodule Xcribe.Config do
 
   To configure output name:
 
-      config :xcribe, :configuration, [
+      config :xcribe, [
         output: "custom_name.json"
       ]
   """
@@ -54,7 +55,7 @@ defmodule Xcribe.Config do
 
   To configure the documentation format:
 
-      config :xcribe, :configuration, [
+      config :xcribe, [
         format: :swagger
       ]
   """
@@ -72,7 +73,7 @@ defmodule Xcribe.Config do
 
   The env var name can changed by configuration:
 
-      config :xcribe, :configuration, [
+      config :xcribe, [
         env_var: "CUSTOM_ENV_NAME"
       ]
   """
@@ -85,7 +86,7 @@ defmodule Xcribe.Config do
 
   To configure the source:
 
-      config :xcribe, :configuration, [
+      config :xcribe, [
         information_source: YourApp.YouModuleInformation
       ]
   """
@@ -103,7 +104,7 @@ defmodule Xcribe.Config do
 
   To configure:
 
-      config :xcribe, :configuration, [
+      config :xcribe, [
         json_library: Jason
       ]
 
@@ -130,11 +131,7 @@ defmodule Xcribe.Config do
     end
   end
 
-  defp new_config(key) do
-    :xcribe
-    |> Application.get_env(:configuration, [])
-    |> Keyword.get(key)
-  end
+  defp new_config(key), do: Application.get_env(:xcribe, key)
 
   defp old_config(key), do: Application.get_env(:xcribe, rename_key(key))
 

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -10,15 +10,21 @@ defmodule Xcribe.Config do
         env_var: "CI_ENV_FOR_DOC"
       ]
 
+      :api_blueprint -> "api_doc.apib"
+      :swagger -> "openapi.json"
 
   ### Available configurations:
     * `:information_source` - Module that implements `Xcribe.Information` with
-    API information.
-    * `:output` - The name of file output with generated configuration.
-    * `:format` - Format to generate documentation, allowed :api_blueprint and
-    :swagger.
+    API information. It's required.
+    * `:output` - The name of file output with generated configuration. Default
+    value changes by the format, 'api_blueprint.apib' for Blueprint and
+    'app_doc.json' for swagger.
+    * `:format` - Format to generate documentation, allowed `:api_blueprint` and
+    `:swagger`. Default `:api_blueprint`.
     * `:env_var` - Environment variable name for active Xcribe documentation
-    generator.
+    generator. Default is `XCRIBE_ENV`.
+    * `:json_library` - The library to be used for json decode/encode (Jason
+    and Poison are supported). The default is the same as `Phoenix` configuration.
   """
 
   alias Xcribe.{MissingInformationSource, UnknownFormat}
@@ -33,7 +39,7 @@ defmodule Xcribe.Config do
 
   To configure output name:
 
-      config :xcribe, [
+      config :xcribe, :configuration, [
         output: "custom_name.json"
       ]
   """
@@ -47,7 +53,7 @@ defmodule Xcribe.Config do
 
   To configure the documentation format:
 
-      config :xcribe, [
+      config :xcribe, :configuration, [
         format: :swagger
       ]
   """
@@ -65,7 +71,7 @@ defmodule Xcribe.Config do
 
   The env var name can changed by configuration:
 
-      config :xcribe, [
+      config :xcribe, :configuration, [
         env_var: "CUSTOM_ENV_NAME"
       ]
   """
@@ -78,7 +84,7 @@ defmodule Xcribe.Config do
 
   To configure the source:
 
-      config :xcribe, [
+      config :xcribe, :configuration, [
         information_source: YourApp.YouModuleInformation
       ]
   """
@@ -88,6 +94,20 @@ defmodule Xcribe.Config do
       information_source -> information_source
     end
   end
+
+  @doc """
+  Return configured json library.
+
+  If no custom lib was configured the `Phoenix` configuration will be used.
+
+  To configure:
+
+      config :xcribe, :configuration, [
+        json_library: Jason
+      ]
+
+  """
+  def json_library, do: get_xcribe_config(:json_library, Phoenix.json_library())
 
   defp env_var_name, do: get_xcribe_config(:env_var, "XCRIBE_ENV")
 

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -7,7 +7,8 @@ defmodule Xcribe.Config do
         information_source: YourApp.YouModuleInformation,
         format: :swagger,
         output: "app_doc.json",
-        env_var: "CI_ENV_FOR_DOC"
+        env_var: "CI_ENV_FOR_DOC",
+        json_library: Jason
       ]
 
       :api_blueprint -> "api_doc.apib"

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -3,7 +3,7 @@ defmodule Xcribe.Config do
   Handle Xcribe configurations.
 
   You must configure Xcribe in your test config file `config/test.exs` as:
-      config: xcribe, :configuration, [
+      config :xcribe, :configuration, [
         information_source: YourApp.YouModuleInformation,
         format: :swagger,
         output: "app_doc.json",

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -21,7 +21,7 @@ defmodule Xcribe.Config do
     generator.
   """
 
-  alias Xcribe.UnknownFormat
+  alias Xcribe.{MissingInformationSource, UnknownFormat}
 
   @valid_formats [:api_blueprint, :swagger]
 
@@ -42,8 +42,8 @@ defmodule Xcribe.Config do
   @doc """
   Return the format for documentation.
 
-  Default is `:api_blueprint`. If an invalid format is given an exception will
-  raise.
+  Default is `:api_blueprint`. If an invalid format is given an `Xcribe.UnknownFormat`
+  exception will raise.
 
   To configure the documentation format:
 
@@ -74,7 +74,7 @@ defmodule Xcribe.Config do
   @doc """
   Return the iformation module with API information (`Xcribe.Information`).
 
-  If information source is not given an excpiton will raise.
+  If information source is not given an `Xcribe.MissingInformationSource` exception will raise.
 
   To configure the source:
 
@@ -82,8 +82,12 @@ defmodule Xcribe.Config do
         information_source: YourApp.YouModuleInformation
       ]
   """
-  def xcribe_information_source,
-    do: Application.fetch_env!(:xcribe, :information_source)
+  def xcribe_information_source do
+    case get_xcribe_config(:information_source) do
+      nil -> raise MissingInformationSource
+      information_source -> information_source
+    end
+  end
 
   defp env_var_name, do: get_xcribe_config(:env_var, "XCRIBE_ENV")
 
@@ -97,7 +101,7 @@ defmodule Xcribe.Config do
   defp validate_doc_format(format) when format in @valid_formats, do: format
   defp validate_doc_format(format), do: raise(UnknownFormat, format)
 
-  defp get_xcribe_config(key, default) do
+  defp get_xcribe_config(key, default \\ nil) do
     cond do
       value = new_config(key) -> value
       value = old_config(key) -> value

--- a/lib/content_decoder.ex
+++ b/lib/content_decoder.ex
@@ -1,0 +1,38 @@
+defmodule Xcribe.ContentDecoder do
+  @moduledoc """
+  Used to decode requests content to an elixir collection (map, list, etc)
+
+  Currently only json is supported and the module `Xcribe.JSON` is used to
+  decode given value.
+  """
+
+  alias Xcribe.ContentDecoder.UnknownType
+  alias Xcribe.JSON
+
+  @json_format_regex ~r{application\/json|application\/vnd\..*json}
+
+  @doc """
+  Decode value by the given content_type.
+
+      iex> ContentDecoder.decode!("{\"key\":\"value\"}", "application/json")
+      %{"key" => "value"}
+
+  An UnknownType excption is raised when given content_type is unknown.
+  """
+  def decode!(value, content_type) do
+    content_type
+    |> define_format()
+    |> decode_for(value)
+  end
+
+  defp decode_for(:json, value), do: JSON.decode!(value)
+
+  defp define_format(content_type) do
+    cond do
+      is_json?(content_type) -> :json
+      true -> raise UnknownType, content_type
+    end
+  end
+
+  defp is_json?(content_type), do: Regex.match?(@json_format_regex, content_type)
+end

--- a/lib/content_decoder.ex
+++ b/lib/content_decoder.ex
@@ -28,9 +28,10 @@ defmodule Xcribe.ContentDecoder do
   defp decode_for(:json, value), do: JSON.decode!(value)
 
   defp define_format(content_type) do
-    cond do
-      is_json?(content_type) -> :json
-      true -> raise UnknownType, content_type
+    if is_json?(content_type) do
+      :json
+    else
+      raise UnknownType, content_type
     end
   end
 

--- a/lib/exceptions.ex
+++ b/lib/exceptions.ex
@@ -29,3 +29,22 @@ defmodule Xcribe.UnknownFormat do
     %__MODULE__{message: "Configured format #{format} is unknown. \n#{@help_information}"}
   end
 end
+
+defmodule Xcribe.MissingInformationSource do
+  @moduledoc """
+  Raised at runtime when not configured an implementation of `Xcribe.Information`.
+  """
+
+  @help_information ~S"""
+  You must create a module to implement `Xcribe.Information` and configure it:
+
+      config: :xcribe, :configuration, information_source: YourInformationModule
+
+  """
+
+  defexception [:message]
+
+  def exception(_) do
+    %__MODULE__{message: "Information Source module not configured. \n#{@help_information}"}
+  end
+end

--- a/lib/exceptions.ex
+++ b/lib/exceptions.ex
@@ -1,0 +1,11 @@
+defmodule Xcribe.ContentDecoder.UnknownType do
+  @moduledoc """
+  Raised at runtime when can't decode an unknown content type.
+  """
+
+  defexception [:message]
+
+  def exception(type) do
+    %__MODULE__{message: "Couldn't decode value. Type #{type} is unknown."}
+  end
+end

--- a/lib/exceptions.ex
+++ b/lib/exceptions.ex
@@ -9,3 +9,23 @@ defmodule Xcribe.ContentDecoder.UnknownType do
     %__MODULE__{message: "Couldn't decode value. Type #{type} is unknown."}
   end
 end
+
+defmodule Xcribe.UnknownFormat do
+  @moduledoc """
+  Raised at runtime when configured format is unknown.
+  """
+
+  @help_information ~S"""
+  Current supported formats are :api_blueprint and :swagger.
+
+  You should configure it in your `test/config` as:
+      config: :xcribe, :configuration, format: :swagger
+
+  """
+
+  defexception [:message]
+
+  def exception(format) do
+    %__MODULE__{message: "Configured format #{format} is unknown. \n#{@help_information}"}
+  end
+end

--- a/lib/helpers/formatter.ex
+++ b/lib/helpers/formatter.ex
@@ -11,7 +11,7 @@ defmodule Xcribe.Helpers.Formatter do
   @mult_spaces_regex ~r/\s+/
   @slash_regex ~r/\/$/
   @path_ending_arg_regex ~r/({\w*}\/$)/
-  @content_type_regex ~r/^(\w*\/\w*),?.*/
+  @content_type_regex ~r{^(\w*\/\w*(\.\w*\+\w*)?);?.*}
 
   @doc """
   return the content type by a list of header params
@@ -142,6 +142,7 @@ defmodule Xcribe.Helpers.Formatter do
 
   defp handle_content_type_regex(nil), do: {:halt, nil}
   defp handle_content_type_regex([content_type]), do: {:halt, content_type}
+  defp handle_content_type_regex([content_type | _vnd_spec]), do: {:halt, content_type}
 
   defp unify_matchs(nil), do: []
   defp unify_matchs(matchs), do: Enum.uniq(matchs)

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -1,16 +1,36 @@
 defmodule Xcribe.JSON do
+  @moduledoc """
+  Wrapper for a JSON library.
+
+  Poison and Jason are the most popular json libraries common used in Elixir
+  projects. Xcribe works with both. By default Xcribe use the same library as
+  Phoenix. But you can change it by config.
+  """
+
+  @doc """
+  wrapper for json library encode function
+  """
   def encode(value, options \\ []) do
     json_library().encode(value, options)
   end
 
+  @doc """
+  wrapper for json library encode! function
+  """
   def encode!(value, options \\ []) do
     json_library().encode!(value, options)
   end
 
+  @doc """
+  wrapper for json library decode function
+  """
   def decode(value, options \\ []) do
     json_library().decode(value, options)
   end
 
+  @doc """
+  wrapper for json library decode! function
+  """
   def decode!(value, options \\ []) do
     json_library().decode!(value, options)
   end

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -4,8 +4,9 @@ defmodule Xcribe.JSON do
 
   Poison and Jason are the most popular json libraries common used in Elixir
   projects. Xcribe works with both. By default Xcribe use the same library as
-  Phoenix. But you can change it by config.
+  Phoenix. But you can change it by config, see `Xcribe.Config`.
   """
+  alias Xcribe.Config
 
   @doc """
   wrapper for json library encode function
@@ -35,5 +36,5 @@ defmodule Xcribe.JSON do
     json_library().decode!(value, options)
   end
 
-  defp json_library, do: Jason
+  defp json_library, do: Config.json_library()
 end

--- a/lib/swagger/formatter.ex
+++ b/lib/swagger/formatter.ex
@@ -5,7 +5,7 @@ defmodule Xcribe.Swagger.Formatter do
   To know more about the specifications [OpenAPI 3.0.3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md)
   """
 
-  alias Xcribe.{JSON, Request}
+  alias Xcribe.{ContentDecoder, Request}
   alias Xcribe.Swagger.Types
 
   import Xcribe.Helpers.Formatter, only: [content_type: 1, authorization: 1]
@@ -207,14 +207,13 @@ defmodule Xcribe.Swagger.Formatter do
     }
   end
 
-  defp build_schema_for_media(content, "application/json") when is_binary(content) do
-    schema_object_for({:build_schema_for_media, JSON.decode!(content)},
-      title: false,
-      example: true
-    )
+  defp build_schema_for_media(content, content_type) when is_binary(content) do
+    content
+    |> ContentDecoder.decode!(content_type)
+    |> build_schema_for_media(content_type)
   end
 
-  defp build_schema_for_media(content, _) when is_map(content) do
+  defp build_schema_for_media(content, _) do
     schema_object_for({:build_schema_for_media, content}, title: false, example: true)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -88,10 +88,6 @@ defmodule Xcribe.MixProject do
       Helpers: [
         Xcribe.Helpers.Document,
         Xcribe.Helpers.Formatter
-      ],
-      Exceptions: [
-        Xcribe.UnknownFormat,
-        Xcribe.ContentDecoder.UnknownType
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/danielwsx64/xcribe"}
 
@@ -88,6 +88,10 @@ defmodule Xcribe.MixProject do
       Helpers: [
         Xcribe.Helpers.Document,
         Xcribe.Helpers.Formatter
+      ],
+      Exceptions: [
+        Xcribe.UnknownFormat,
+        Xcribe.ContentDecoder.UnknownType
       ]
     ]
   end

--- a/test/lib/api_blueprint/api_blueprint_test.exs
+++ b/test/lib/api_blueprint/api_blueprint_test.exs
@@ -5,6 +5,12 @@ defmodule Xcribe.ApiBlueprintTest do
 
   alias Xcribe.ApiBlueprint
 
+  setup do
+    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+
+    :ok
+  end
+
   describe "group_requests/1" do
     test "group requests" do
       assert ApiBlueprint.group_requests(@sample_requests) == @grouped_sample_requests

--- a/test/lib/api_blueprint/api_blueprint_test.exs
+++ b/test/lib/api_blueprint/api_blueprint_test.exs
@@ -6,7 +6,7 @@ defmodule Xcribe.ApiBlueprintTest do
   alias Xcribe.ApiBlueprint
 
   setup do
-    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+    Application.put_env(:xcribe, :information_source, Xcribe.Support.Information)
 
     :ok
   end

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -2,7 +2,7 @@ defmodule Xcribe.ConfigTest do
   use ExUnit.Case, async: false
 
   alias Xcribe.Config
-  alias Xcribe.UnknownFormat
+  alias Xcribe.{MissingInformationSource, UnknownFormat}
 
   describe "output_file/0" do
     test "return configured output name" do
@@ -120,6 +120,27 @@ defmodule Xcribe.ConfigTest do
       end
 
       Application.delete_env(:xcribe, :doc_format)
+    end
+  end
+
+  describe "xcribe_information_source/0" do
+    test "return information source" do
+      Application.put_env(:xcribe, :configuration, information_source: FakeOne)
+      assert Config.xcribe_information_source() == FakeOne
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "when module is not configured" do
+      assert_raise MissingInformationSource, fn ->
+        Config.xcribe_information_source()
+      end
+    end
+
+    test "deprecated configuration" do
+      # return information source
+      Application.put_env(:xcribe, :information_source, FakeOne)
+      assert Config.xcribe_information_source() == FakeOne
+      Application.delete_env(:xcribe, :information_source)
     end
   end
 end

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -143,4 +143,16 @@ defmodule Xcribe.ConfigTest do
       Application.delete_env(:xcribe, :information_source)
     end
   end
+
+  describe "json_library/o" do
+    test "return configured json library" do
+      Application.put_env(:xcribe, :configuration, json_library: FakeOne)
+      assert Config.json_library() == FakeOne
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "return Phoenix configured json library" do
+      assert Config.json_library() == Jason
+    end
+  end
 end

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -2,64 +2,124 @@ defmodule Xcribe.ConfigTest do
   use ExUnit.Case, async: false
 
   alias Xcribe.Config
-
-  setup_all do
-    System.put_env("EXISTING_ENV_VAR", "1")
-  end
+  alias Xcribe.UnknownFormat
 
   describe "output_file/0" do
-    test "return the output file setuped at config" do
-      Application.put_env(:xcribe, :output_file, "example.md")
-
+    test "return configured output name" do
+      Application.put_env(:xcribe, :configuration, output: "example.md")
       assert Config.output_file() == "example.md"
+      Application.delete_env(:xcribe, :configuration)
     end
 
     test "return default file name for ApiBlueprint" do
-      Application.put_env(:xcribe, :doc_format, :api_blueprint)
-      Application.delete_env(:xcribe, :output_file)
-
+      Application.put_env(:xcribe, :configuration, format: :api_blueprint)
       assert Config.output_file() == "api_doc.apib"
+      Application.delete_env(:xcribe, :configuration)
     end
 
     test "return default file name for Swagger" do
-      Application.put_env(:xcribe, :doc_format, :swagger)
+      Application.put_env(:xcribe, :configuration, format: :swagger)
+      assert Config.output_file() == "openapi.json"
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "deprecated configuration" do
+      # return the output file setted at config
+      Application.put_env(:xcribe, :output_file, "example.md")
+      assert Config.output_file() == "example.md"
       Application.delete_env(:xcribe, :output_file)
 
+      # return default file name for ApiBlueprint
+      Application.put_env(:xcribe, :doc_format, :api_blueprint)
+      assert Config.output_file() == "api_doc.apib"
+      Application.delete_env(:xcribe, :doc_format)
+
+      # return default file name for Swagger
+      Application.put_env(:xcribe, :doc_format, :swagger)
       assert Config.output_file() == "openapi.json"
+      Application.delete_env(:xcribe, :doc_format)
     end
   end
 
   describe "active?/0" do
     test "return true when xcribe env var is defined" do
-      Application.put_env(:xcribe, :env_var, "EXISTING_ENV_VAR")
+      Application.put_env(:xcribe, :configuration, env_var: "EXISTING_ENV_VAR_NEW_CONFIG")
+      System.put_env("EXISTING_ENV_VAR_NEW_CONFIG", "1")
+
+      assert Config.active?() == true
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "return false when xcribe env var is undefined" do
+      Application.put_env(:xcribe, :configuration, env_var: "UNDEFINED_XCRIBE_ENV_VAR_!@#")
+
+      assert Config.active?() == false
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "return true for default env var name" do
+      System.put_env("XCRIBE_ENV", "1")
 
       assert Config.active?() == true
     end
 
-    test "return false when xcribe env var is undefined" do
-      Application.put_env(:xcribe, :env_var, "UNDEFINED_XCRIBE_ENV_VAR_!@#")
+    test "deprecated configuration" do
+      # return true when xcribe env var is defined
+      Application.put_env(:xcribe, :env_var, "EXISTING_ENV_VAR")
+      System.put_env("EXISTING_ENV_VAR", "1")
+      assert Config.active?() == true
 
+      # return false when xcribe env var is undefined
+      Application.put_env(:xcribe, :env_var, "UNDEFINED_XCRIBE_ENV_VAR_!@#")
       assert Config.active?() == false
+      Application.delete_env(:xcribe, :env_var)
     end
   end
 
   describe "doc_format/0" do
     test "when ApiBlueprint format is specified" do
-      Application.put_env(:xcribe, :doc_format, :api_blueprint)
+      Application.put_env(:xcribe, :configuration, format: :api_blueprint)
 
       assert Config.doc_format() == :api_blueprint
+      Application.delete_env(:xcribe, :configuration)
     end
 
     test "when Swagger format is specified" do
-      Application.put_env(:xcribe, :doc_format, :swagger)
+      Application.put_env(:xcribe, :configuration, format: :swagger)
 
       assert Config.doc_format() == :swagger
+      Application.delete_env(:xcribe, :configuration)
     end
 
     test "when an invalid format is specified" do
+      Application.put_env(:xcribe, :configuration, format: :invalid)
+
+      assert_raise UnknownFormat, fn ->
+        Config.doc_format()
+      end
+
+      Application.delete_env(:xcribe, :configuration)
+    end
+
+    test "deprecated configuration" do
+      # when ApiBlueprint format is specified
+      Application.put_env(:xcribe, :doc_format, :api_blueprint)
+      assert Config.doc_format() == :api_blueprint
+      Application.delete_env(:xcribe, :doc_format)
+
+      # when Swagger format is specified
+      Application.put_env(:xcribe, :doc_format, :swagger)
+      assert Config.doc_format() == :swagger
+      Application.delete_env(:xcribe, :doc_format)
+
+      # when an invalid format is specified
       Application.put_env(:xcribe, :doc_format, :invalid)
 
-      assert Config.doc_format() == :error
+      assert_raise UnknownFormat, fn ->
+        Config.doc_format()
+      end
+
+      Application.delete_env(:xcribe, :doc_format)
     end
   end
 end

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -6,21 +6,21 @@ defmodule Xcribe.ConfigTest do
 
   describe "output_file/0" do
     test "return configured output name" do
-      Application.put_env(:xcribe, :configuration, output: "example.md")
+      Application.put_env(:xcribe, :output, "example.md")
       assert Config.output_file() == "example.md"
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :output)
     end
 
     test "return default file name for ApiBlueprint" do
-      Application.put_env(:xcribe, :configuration, format: :api_blueprint)
+      Application.put_env(:xcribe, :format, :api_blueprint)
       assert Config.output_file() == "api_doc.apib"
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :format)
     end
 
     test "return default file name for Swagger" do
-      Application.put_env(:xcribe, :configuration, format: :swagger)
+      Application.put_env(:xcribe, :format, :swagger)
       assert Config.output_file() == "openapi.json"
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :format)
     end
 
     test "deprecated configuration" do
@@ -43,18 +43,18 @@ defmodule Xcribe.ConfigTest do
 
   describe "active?/0" do
     test "return true when xcribe env var is defined" do
-      Application.put_env(:xcribe, :configuration, env_var: "EXISTING_ENV_VAR_NEW_CONFIG")
+      Application.put_env(:xcribe, :env_var, "EXISTING_ENV_VAR_NEW_CONFIG")
       System.put_env("EXISTING_ENV_VAR_NEW_CONFIG", "1")
 
       assert Config.active?() == true
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :env_var)
     end
 
     test "return false when xcribe env var is undefined" do
-      Application.put_env(:xcribe, :configuration, env_var: "UNDEFINED_XCRIBE_ENV_VAR_!@#")
+      Application.put_env(:xcribe, :env_var, "UNDEFINED_XCRIBE_ENV_VAR_!@#")
 
       assert Config.active?() == false
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :env_var)
     end
 
     test "return true for default env var name" do
@@ -78,27 +78,27 @@ defmodule Xcribe.ConfigTest do
 
   describe "doc_format/0" do
     test "when ApiBlueprint format is specified" do
-      Application.put_env(:xcribe, :configuration, format: :api_blueprint)
+      Application.put_env(:xcribe, :format, :api_blueprint)
 
       assert Config.doc_format() == :api_blueprint
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :format)
     end
 
     test "when Swagger format is specified" do
-      Application.put_env(:xcribe, :configuration, format: :swagger)
+      Application.put_env(:xcribe, :format, :swagger)
 
       assert Config.doc_format() == :swagger
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :format)
     end
 
     test "when an invalid format is specified" do
-      Application.put_env(:xcribe, :configuration, format: :invalid)
+      Application.put_env(:xcribe, :format, :invalid)
 
       assert_raise UnknownFormat, fn ->
         Config.doc_format()
       end
 
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :format)
     end
 
     test "deprecated configuration" do
@@ -125,9 +125,9 @@ defmodule Xcribe.ConfigTest do
 
   describe "xcribe_information_source/0" do
     test "return information source" do
-      Application.put_env(:xcribe, :configuration, information_source: FakeOne)
+      Application.put_env(:xcribe, :information_source, FakeOne)
       assert Config.xcribe_information_source() == FakeOne
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :information_source)
     end
 
     test "when module is not configured" do
@@ -146,9 +146,9 @@ defmodule Xcribe.ConfigTest do
 
   describe "json_library/o" do
     test "return configured json library" do
-      Application.put_env(:xcribe, :configuration, json_library: FakeOne)
+      Application.put_env(:xcribe, :json_library, FakeOne)
       assert Config.json_library() == FakeOne
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :json_library)
     end
 
     test "return Phoenix configured json library" do

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -131,6 +131,8 @@ defmodule Xcribe.ConfigTest do
     end
 
     test "when module is not configured" do
+      Application.delete_env(:xcribe, :information_source)
+
       assert_raise MissingInformationSource, fn ->
         Config.xcribe_information_source()
       end

--- a/test/lib/conn_parser_test.exs
+++ b/test/lib/conn_parser_test.exs
@@ -4,6 +4,12 @@ defmodule Xcribe.ConnParserTest do
   alias Plug.Conn
   alias Xcribe.{ConnParser, Request}
 
+  setup do
+    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+
+    :ok
+  end
+
   describe "parse/1" do
     test "extract request data from an index request", %{conn: conn} do
       conn =

--- a/test/lib/conn_parser_test.exs
+++ b/test/lib/conn_parser_test.exs
@@ -5,7 +5,7 @@ defmodule Xcribe.ConnParserTest do
   alias Xcribe.{ConnParser, Request}
 
   setup do
-    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+    Application.put_env(:xcribe, :information_source, Xcribe.Support.Information)
 
     :ok
   end

--- a/test/lib/content_decoder_test.exs
+++ b/test/lib/content_decoder_test.exs
@@ -1,0 +1,27 @@
+defmodule Xcribe.ContentDecoderTest do
+  use ExUnit.Case, async: true
+
+  alias Xcribe.ContentDecoder
+  alias Xcribe.ContentDecoder.UnknownType
+
+  describe "decode!/2" do
+    test "decode content when type is know json" do
+      value = "{\"key\":\"value\"}"
+
+      assert ContentDecoder.decode!(value, "application/json") == %{"key" => "value"}
+      assert ContentDecoder.decode!(value, "application/vnd.api+json") == %{"key" => "value"}
+    end
+
+    test "raise UnknownType when content_type is unknown" do
+      assert_raise UnknownType, "Couldn't decode value. Type application/xml is unknown.", fn ->
+        assert ContentDecoder.decode!("", "application/xml")
+      end
+    end
+
+    test "raise blabla when value cant be decoded" do
+      assert_raise Jason.DecodeError, fn ->
+        assert ContentDecoder.decode!("invalidjson", "application/json")
+      end
+    end
+  end
+end

--- a/test/lib/helpers/document_test.exs
+++ b/test/lib/helpers/document_test.exs
@@ -6,9 +6,8 @@ defmodule Xcribe.Helpers.DocumentTest do
   import Xcribe.Helpers.Document
 
   setup do
-    Application.put_all_env(
-      xcribe: [env_var: "PWD", information_source: Xcribe.Support.Information]
-    )
+    Application.put_env(:xcribe, :information_source, Xcribe.Support.Information)
+    Application.put_env(:xcribe, :env_var, "PWD")
 
     :ok
   end

--- a/test/lib/helpers/document_test.exs
+++ b/test/lib/helpers/document_test.exs
@@ -6,9 +6,8 @@ defmodule Xcribe.Helpers.DocumentTest do
   import Xcribe.Helpers.Document
 
   setup do
-    Application.put_env(:xcribe, :configuration,
-      env_var: "PWD",
-      information_source: Xcribe.Support.Information
+    Application.put_all_env(
+      xcribe: [env_var: "PWD", information_source: Xcribe.Support.Information]
     )
 
     :ok
@@ -47,7 +46,7 @@ defmodule Xcribe.Helpers.DocumentTest do
     end
 
     test "dont document when env var is not defined", %{conn: conn} do
-      Application.delete_env(:xcribe, :configuration)
+      Application.delete_env(:xcribe, :env_var)
 
       Recorder.start_link()
 

--- a/test/lib/helpers/document_test.exs
+++ b/test/lib/helpers/document_test.exs
@@ -6,7 +6,11 @@ defmodule Xcribe.Helpers.DocumentTest do
   import Xcribe.Helpers.Document
 
   setup do
-    Application.put_env(:xcribe, :env_var, "PWD")
+    Application.put_env(:xcribe, :configuration,
+      env_var: "PWD",
+      information_source: Xcribe.Support.Information
+    )
+
     :ok
   end
 
@@ -43,7 +47,7 @@ defmodule Xcribe.Helpers.DocumentTest do
     end
 
     test "dont document when env var is not defined", %{conn: conn} do
-      Application.put_env(:xcribe, :env_var, "UNDEFINED_XCRIBE_ENV_VAR_!@#")
+      Application.delete_env(:xcribe, :configuration)
 
       Recorder.start_link()
 

--- a/test/lib/helpers/formatter_test.exs
+++ b/test/lib/helpers/formatter_test.exs
@@ -18,6 +18,11 @@ defmodule Xcribe.Helpers.FormatterTest do
       assert Formatter.content_type(headers_three) == nil
     end
 
+    test "handle composed vnd type" do
+      headers = [{"content-type", "application/vnd.api+json; charset=utf-8"}]
+      assert Formatter.content_type(headers) == "application/vnd.api+json"
+    end
+
     test "return default value when not found" do
       headers_one = [
         {"content-type", "application/json; charset=utf-8"},

--- a/test/lib/swagger/swagger_test.exs
+++ b/test/lib/swagger/swagger_test.exs
@@ -6,6 +6,12 @@ defmodule Xcribe.SwaggerTest do
   alias Xcribe.Support.RequestsGenerator
   alias Xcribe.Swagger
 
+  setup do
+    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+
+    :ok
+  end
+
   describe "generate_doc/1" do
     test "parse requests do string" do
       requests = [

--- a/test/lib/swagger/swagger_test.exs
+++ b/test/lib/swagger/swagger_test.exs
@@ -7,7 +7,7 @@ defmodule Xcribe.SwaggerTest do
   alias Xcribe.Swagger
 
   setup do
-    Application.put_env(:xcribe, :configuration, information_source: Xcribe.Support.Information)
+    Application.put_env(:xcribe, :information_source, Xcribe.Support.Information)
 
     :ok
   end


### PR DESCRIPTION
### Motivation
When document an endpoint with `application/vnd.api+json` content type we got this exception:

```elixir
13:09:25.455 [error] GenServer #PID<0.848.0> terminating                                                                                                                                                                                                                                                                                                                   
** (FunctionClauseError) no function clause matching in Xcribe.Swagger.Formatter.build_schema_for_media/2                                                                                                                                                                                                                                                                  
    (xcribe 0.2.0) lib/swagger/formatter.ex:210: Xcribe.Swagger.Formatter.build_schema_for_media("{\"data\":[{\"attributes\":{\"name\":\"Uma Escola inc\"},\"id\":\"1c2180ef-ccae-42c6-9605-ad63ef331e7b\",\"type\":\"school\"}],\"jsonapi\":{\"version\":\"1.0\"}}", "application/vnd")                                                                                   
    (xcribe 0.2.0) lib/swagger/formatter.ex:205: Xcribe.Swagger.Formatter.media_type_object/2                                                                                                                                                                                                                                                                              
    (xcribe 0.2.0) lib/swagger/formatter.ex:71: Xcribe.Swagger.Formatter.response_object_from_request/1                                                                                                                                                                                                                                                                    
    (xcribe 0.2.0) lib/swagger/formatter.ex:194: Xcribe.Swagger.Formatter.responses_object_from_request/1                                                                                                                                                                                                                                                                  
    (xcribe 0.2.0) lib/swagger/formatter.ex:51: Xcribe.Swagger.Formatter.path_item_object_from_request/1                                                                                                                                                                                                                                                                   
    (xcribe 0.2.0) lib/swagger/swagger.ex:45: Xcribe.Swagger.paths_object_func/2                                                                                                                                                                                                                                                                                           
    (elixir 1.10.1) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3                                                                                                                                                                                                                                                                                                  
    (xcribe 0.2.0) lib/swagger/swagger.ex:25: Xcribe.Swagger.mount_data_in_raw_object/2                                                                                                                                                                                                                                                                                    
    (xcribe 0.2.0) lib/swagger/swagger.ex:16: Xcribe.Swagger.generate_doc/1                                                                                                                                                                                                                                                                                                
    (xcribe 0.2.0) lib/formatter.ex:15: Xcribe.Formatter.handle_cast/2                                                                                                                                                                                                                                                                                                     
    (stdlib 3.6) gen_server.erl:637: :gen_server.try_dispatch/4                                                                                                                                                                                                                                                                                                            
    (stdlib 3.6) gen_server.erl:711: :gen_server.handle_msg/6                                                                                                                                                                                                                                                                                                              
    (stdlib 3.6) proc_lib.erl:249: :proc_lib.init_p_do_apply/3                                                                                                                                                                                                                                                                                                             
Last message: {:"$gen_cast", {:suite_finished, 941843, nil}}    
```

There are some issues about this
1. The function `Xcribe.Helpers.Formatter.content_type/2` don't return the entire content type value. It's return just `application/vnd`.
1. The `Xcribe.Swagger.Formatter` just expect `application/json` format.
1. The `Formatter` decide how decode the value by "patter matching"  the content type. That makes the stacktrace noising.

### Proposed Solution

1. Refactored `Xcribe.Helpers.Formatter.content_type` to return the correct content type.
1. Created `Xcribe.ContentDecoder` and delegate to it the decoding of all know formats.
1. Document `Xcribe.Config`, add new config spec and make `json_library` configurable.