### PR TITLE
Add CHANGELOG.md and Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Add changelog and Makefile.
+
+[Unreleased]: https://github.com/brainn-co/xcribe/compa...master

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+.DEFAULT_GOAL := help
+
+VERSION_FILE := mix.exs
+VERSION := $(shell sed -En "s/^.*@version \"([0-9]*\\.[0-9]*\\.[0-9]*)\"*/\\1/p" ${VERSION_FILE})
+
+BLUE_COLOR := \033[0;34m
+DEFAULT_COLOR := \033[0;39m
+DIM_COLOR := \033[0;2m
+YELLOW_COLOR := \033[0;33m
+
+MAJOR := $(shell echo "${VERSION}" | cut -d . -f1)
+MINOR := $(shell echo "${VERSION}" | cut -d . -f2)
+PATCH := $(shell echo "${VERSION}" | cut -d . -f3)
+README_FILE := README.md
+CHANGELOG_FILE := CHANGELOG.md
+DATE := $(shell date +"%Y-%m-%d")
+REPO_NAME := xcribe
+REPO := https:\/\/github.com\/brainn-co\/${REPO_NAME}\/compare
+
+.PHONY: release
+release: ## Bumps the version and creates the new tag
+	@printf "${BLUE_COLOR}The current version is:${DEFAULT_COLOR} ${VERSION}\n" && \
+	  read -r -p "Do you want to release a [major|minor|patch]: " TYPE && \
+	  case "$$TYPE" in \
+	  "major") \
+	    MAJOR=$$((${MAJOR}+1)); \
+	    MINOR="0"; \
+	    PATCH="0"; \
+	    NEW_VERSION="$$MAJOR.$$MINOR.$$PATCH" \
+	    ;; \
+	  "minor") \
+	    MINOR=$$((${MINOR}+1)); \
+	    PATCH="0" && \
+	    NEW_VERSION="${MAJOR}.$$MINOR.$$PATCH" \
+	    ;; \
+	  "patch") \
+	    PATCH=$$((${PATCH}+1)); \
+	    NEW_VERSION="${MAJOR}.${MINOR}.$$PATCH" \
+	    ;; \
+	  *) \
+	    printf "\\n${YELLOW_COLOR}Release canceled!\n"; \
+	    exit 0 \
+	    ;; \
+	  esac && \
+	  printf "${BLUE_COLOR}The new version is:${DEFAULT_COLOR} $$NEW_VERSION\n" && \
+	  printf "\t${DIM_COLOR}Updating ${VERSION_FILE} version${DEFAULT_COLOR}\n" && \
+	  perl -p -i -e "s/@version \"${VERSION}\"/@version \"$$NEW_VERSION\"/g" ${VERSION_FILE} && \
+	  printf "\t${DIM_COLOR}Updating ${README_FILE} version${DEFAULT_COLOR}\n" && \
+	  perl -p -i -e "s/\"\~> ${VERSION}\"/\"\~> $$NEW_VERSION\"/g" ${README_FILE} && \
+	  printf "\t${DIM_COLOR}Updating ${CHANGELOG_FILE} version${DEFAULT_COLOR}\n" && \
+	  perl -p -i -e "s/## \[Unreleased\]/## \[Unreleased\]\\n\\n## \[$$NEW_VERSION\] - ${DATE}/g" ${CHANGELOG_FILE} && \
+	  perl -p -i -e "s/${REPO}\/${VERSION}...master/${REPO}\/$$NEW_VERSION...master/g" ${CHANGELOG_FILE} && \
+	  perl -p -i -e "s/...master/...master\\n\[$$NEW_VERSION\]: ${REPO}\/${VERSION}...$$NEW_VERSION/g" ${CHANGELOG_FILE} && \
+	  printf "\t${DIM_COLOR}Recording changes to the repository${DEFAULT_COLOR}\n" && \
+	  git add ${VERSION_FILE} ${README_FILE} ${CHANGELOG_FILE} && \
+	  git commit -m "Bump to $$NEW_VERSION" > /dev/null && \
+	  printf "\t${DIM_COLOR}Creating release tag${DEFAULT_COLOR}\n" && \
+	  git tag -a -m "" $$NEW_VERSION && \
+	  printf "\n${BLUE_COLOR}If everything's ok, push the changes to updstream!${DEFAULT_COLOR}\n"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.3"}
+    {:xcribe, "~> 0.3.0"}
   ]
 end
 ```


### PR DESCRIPTION
**Motivation**
- Would be great to have a changelog and keep the lib updates and releases on track

**Proposed Solution**
- Adds `CHANGELOG.md`
  * Just insert new changes to  `## [Unreleased]` section with `### Added`, `### Updated` or `### Removed` and the `make release` will update the file later when a relase was launched.

- Adds `Makefile` with `make release`. The user will be prompt and choose which kind of release he wants to:

![image](https://user-images.githubusercontent.com/9864821/80252439-a100a800-864d-11ea-8a6c-3df8d620a901.png)

After that, the script will update the `CHANGELOG.md` the `README.md` and `mix.exs` with the new lib version.

![image](https://user-images.githubusercontent.com/9864821/80252498-bd9ce000-864d-11ea-8a7f-d38b687d5b3a.png)

Than, to publish, you just need to: `git push origin master && git push origin master --tags`
 