### PR TITLE
Add tags parameter to operation object [Swagger]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0]
+## [Unreleased]
 ### Added
 - New "tags" parameter to operations object in Swagger format.
 - Add changelog and Makefile.
 
-[0.4.0]: https://github.com/brainn-co/xcribe/compare/0.4.0...master
+[Unreleased]: https://github.com/brainn-co/xcribe/compa...master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0]
 ### Added
+- New "tags" parameter to operations object in Swagger format.
 - Add changelog and Makefile.
 
-[Unreleased]: https://github.com/brainn-co/xcribe/compa...master
+[0.4.0]: https://github.com/brainn-co/xcribe/compare/0.4.0...master

--- a/lib/swagger/formatter.ex
+++ b/lib/swagger/formatter.ex
@@ -50,7 +50,8 @@ defmodule Xcribe.Swagger.Formatter do
             summary: "",
             responses: responses_object_from_request(request),
             parameters: parameter_objects_from_request(request),
-            security: security_requirement_object_by_request(request)
+            security: security_requirement_object_by_request(request),
+            tags: [request.resource]
           }
         )
     }

--- a/lib/swagger/formatter.ex
+++ b/lib/swagger/formatter.ex
@@ -51,7 +51,7 @@ defmodule Xcribe.Swagger.Formatter do
             responses: responses_object_from_request(request),
             parameters: parameter_objects_from_request(request),
             security: security_requirement_object_by_request(request),
-            tags: [request.resource]
+            tags: format_tags_from_resource(request.resource)
           }
         )
     }
@@ -194,6 +194,8 @@ defmodule Xcribe.Swagger.Formatter do
   defp responses_object_from_request(%Request{status_code: status} = request) do
     %{status => response_object_from_request(request)}
   end
+
+  defp format_tags_from_resource(resource), do: [String.replace(resource, "_", " ")]
 
   defp media_type_object(_headers, ""), do: %{description: ""}
 

--- a/test/lib/swagger/formatter_test.exs
+++ b/test/lib/swagger/formatter_test.exs
@@ -61,6 +61,7 @@ defmodule Xcribe.Swagger.FormatterTest do
         ],
         status_code: 200,
         verb: "get",
+        resource: "users",
         params: %{
           "fields" => %{"articles" => "title,body", "people" => "name"},
           "include" => "author"
@@ -88,6 +89,7 @@ defmodule Xcribe.Swagger.FormatterTest do
           ],
           security: [%{"api_key" => []}],
           summary: "",
+          tags: ["users"],
           responses: %{
             200 => %{
               description: "",
@@ -123,6 +125,7 @@ defmodule Xcribe.Swagger.FormatterTest do
         resp_headers: [{"content-type", "application/json; charset=utf-8"}],
         status_code: 201,
         verb: "post",
+        resource: "users",
         params: %{},
         query_params: %{}
       }
@@ -133,6 +136,7 @@ defmodule Xcribe.Swagger.FormatterTest do
           parameters: [],
           security: [],
           summary: "",
+          tags: ["users"],
           requestBody: %{
             description: "",
             content: %{

--- a/test/lib/swagger/swagger_test.exs
+++ b/test/lib/swagger/swagger_test.exs
@@ -72,6 +72,7 @@ defmodule Xcribe.SwaggerTest do
               "parameters" => [],
               "security" => [],
               "summary" => "",
+              "tags" => ["protocols"],
               "responses" => %{
                 "200" => %{
                   "description" => "",

--- a/test/support/swagger_example.json
+++ b/test/support/swagger_example.json
@@ -65,7 +65,8 @@
         "security": [{
           "basic": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users"]
       },
       "post": {
         "description": "",
@@ -125,7 +126,8 @@
         "security": [{
           "bearer": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users"]
       }
     },
     "/users/{id}": {
@@ -156,7 +158,8 @@
         "security": [{
           "bearer": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users"]
       },
       "get": {
         "description": "",
@@ -203,7 +206,8 @@
         "security": [{
           "basic": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users"]
       },
       "put": {
         "description": "",
@@ -271,7 +275,8 @@
         "security": [{
           "bearer": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users"]
       }
     },
     "/users/{users_id}/cancel": {
@@ -302,7 +307,8 @@
         "security": [{
           "api_key": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users_cancel"]
       }
     },
     "/users/{users_id}/posts": {
@@ -354,7 +360,8 @@
         "security": [{
           "api_key": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users_posts"]
       },
       "post": {
         "description": "",
@@ -416,7 +423,8 @@
         "security": [{
           "api_key": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users_posts"]
       }
     },
     "/users/{users_id}/posts/{id}": {
@@ -490,7 +498,8 @@
         "security": [{
           "api_key": []
         }],
-        "summary": ""
+        "summary": "",
+        "tags": ["users_posts"]
       }
     }
   },

--- a/test/support/swagger_example.json
+++ b/test/support/swagger_example.json
@@ -308,7 +308,7 @@
           "api_key": []
         }],
         "summary": "",
-        "tags": ["users_cancel"]
+        "tags": ["users cancel"]
       }
     },
     "/users/{users_id}/posts": {
@@ -361,7 +361,7 @@
           "api_key": []
         }],
         "summary": "",
-        "tags": ["users_posts"]
+        "tags": ["users posts"]
       },
       "post": {
         "description": "",
@@ -424,7 +424,7 @@
           "api_key": []
         }],
         "summary": "",
-        "tags": ["users_posts"]
+        "tags": ["users posts"]
       }
     },
     "/users/{users_id}/posts/{id}": {
@@ -499,7 +499,7 @@
           "api_key": []
         }],
         "summary": "",
-        "tags": ["users_posts"]
+        "tags": ["users posts"]
       }
     }
   },


### PR DESCRIPTION
## Motivation

It's generally a good idea to group routes by resources or any other qualifier. [OpenAPI Specification](https://swagger.io/specification/) provides a `tags` parameter that groups routes by a common tag.

## Proposed solution

* Adds `tags` parameter to `operation` object in Swagger format.

