### PR TITLE
Deprecate old configuration keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2020-05-27
+
+### Deprecations
+
+- Configuration key `:output_file` in favor of `:output`
+- Configuration key `:doc_format` in favor of `:format`
+
+### Enhancements
+
+-   Xcribe contributing documentation
+
 ## [0.6.0] - 2020-05-23
 
-## Added
+### Added
 
 -   Validate configuration before generate documentation
 -   Handle parsing errors and exceptions and print it friendly
 -   Requests are ordered by path to avoid big diffs btw docs
 -   Write a message with output file path
 
-## Fixed
+### Fixed
 
 -   Use success requests to build Swagger parameter and request body examples
 
-## Enhancements
+### Enhancements
 
 -   Xcribe documentation
 
 ## [0.5.0] - 2020-05-12
 
-## Added
+### Added
 
 -   Automatic publish to hex.pm.
 
@@ -38,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add changelog and Makefile.
 
 [Unreleased]: https://github.com/brainn-co/xcribe/compa...master
+[0.7.0]: https://github.com/brainn-co/xcribe/compare/0.6.0...0.7.0
 
 [0.6.0]: https://github.com/brainn-co/xcribe/compare/0.5.0...0.6.0
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.6.0"}
+    {:xcribe, "~> 0.7.0"}
   ]
 end
 ```

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -164,19 +164,6 @@ defmodule Xcribe.Config do
     end
   end
 
-  defp get_xcribe_config(key, default \\ nil) do
-    cond do
-      value = new_config(key) -> value
-      value = old_config(key) -> value
-      true -> default
-    end
-  end
-
-  defp new_config(key), do: Application.get_env(:xcribe, key)
-
-  defp old_config(key), do: Application.get_env(:xcribe, rename_key(key))
-
-  defp rename_key(:output), do: :output_file
-  defp rename_key(:format), do: :doc_format
-  defp rename_key(key), do: key
+  defp get_xcribe_config(key, default \\ nil),
+    do: Application.get_env(:xcribe, key, default)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/danielwsx64/xcribe"}
 

--- a/test/lib/config_test.exs
+++ b/test/lib/config_test.exs
@@ -6,16 +6,11 @@ defmodule Xcribe.ConfigTest do
 
   setup do
     on_exit(fn ->
-      # Current config keys
       Application.delete_env(:xcribe, :output)
       Application.delete_env(:xcribe, :env_var)
       Application.delete_env(:xcribe, :format)
       Application.delete_env(:xcribe, :json_library)
       Application.delete_env(:xcribe, :information_source)
-
-      # Deprecated config keys
-      Application.delete_env(:xcribe, :output_file)
-      Application.delete_env(:xcribe, :doc_format)
     end)
 
     :ok
@@ -24,7 +19,6 @@ defmodule Xcribe.ConfigTest do
   describe "output_file/0" do
     test "return configured output name" do
       Application.put_env(:xcribe, :output, "example.md")
-      Application.delete_env(:xcribe, :output_file)
       assert Config.output_file() == "example.md"
     end
 
@@ -35,23 +29,6 @@ defmodule Xcribe.ConfigTest do
 
     test "return default file name for Swagger" do
       Application.put_env(:xcribe, :format, :swagger)
-      assert Config.output_file() == "openapi.json"
-    end
-
-    test "deprecated configuration" do
-      # return the output file setted at config
-      Application.put_env(:xcribe, :output_file, "example.md")
-      assert Config.output_file() == "example.md"
-      Application.delete_env(:xcribe, :output_file)
-
-      # return default file name for ApiBlueprint
-      Application.delete_env(:xcribe, :format)
-      Application.put_env(:xcribe, :doc_format, :api_blueprint)
-      assert Config.output_file() == "api_doc.apib"
-      Application.delete_env(:xcribe, :doc_format)
-
-      # return default file name for Swagger
-      Application.put_env(:xcribe, :doc_format, :swagger)
       assert Config.output_file() == "openapi.json"
     end
   end
@@ -75,17 +52,6 @@ defmodule Xcribe.ConfigTest do
 
       assert Config.active?() == true
     end
-
-    test "deprecated configuration" do
-      # return true when xcribe env var is defined
-      Application.put_env(:xcribe, :env_var, "EXISTING_ENV_VAR")
-      System.put_env("EXISTING_ENV_VAR", "1")
-      assert Config.active?() == true
-
-      # return false when xcribe env var is undefined
-      Application.put_env(:xcribe, :env_var, "UNDEFINED_XCRIBE_ENV_VAR_!@#")
-      assert Config.active?() == false
-    end
   end
 
   describe "doc_format!/0" do
@@ -97,16 +63,6 @@ defmodule Xcribe.ConfigTest do
 
     test "when an invalid format is specified" do
       Application.put_env(:xcribe, :format, :invalid)
-
-      assert_raise UnknownFormat, fn ->
-        Config.doc_format!()
-      end
-    end
-
-    test "depecated config invalid" do
-      # when an invalid format is specified
-      Application.delete_env(:xcribe, :format)
-      Application.put_env(:xcribe, :doc_format, :invalid)
 
       assert_raise UnknownFormat, fn ->
         Config.doc_format!()
@@ -124,16 +80,6 @@ defmodule Xcribe.ConfigTest do
     test "when Swagger format is specified" do
       Application.put_env(:xcribe, :format, :swagger)
 
-      assert Config.doc_format() == :swagger
-    end
-
-    test "deprecated configuration" do
-      # when ApiBlueprint format is specified
-      Application.put_env(:xcribe, :doc_format, :api_blueprint)
-      assert Config.doc_format() == :api_blueprint
-
-      # when Swagger format is specified
-      Application.put_env(:xcribe, :doc_format, :swagger)
       assert Config.doc_format() == :swagger
     end
   end
@@ -155,12 +101,6 @@ defmodule Xcribe.ConfigTest do
 
   describe "xcribe_information_source/0" do
     test "return information source" do
-      Application.put_env(:xcribe, :information_source, FakeOne)
-      assert Config.xcribe_information_source() == FakeOne
-    end
-
-    test "deprecated configuration" do
-      # return information source
       Application.put_env(:xcribe, :information_source, FakeOne)
       assert Config.xcribe_information_source() == FakeOne
     end

--- a/test/lib/formatter_test.exs
+++ b/test/lib/formatter_test.exs
@@ -50,7 +50,10 @@ defmodule XcribeFormatterTest do
 
       expected_content = String.replace(@sample_swagger_output, ~r/\s/, "")
 
-      assert Formatter.handle_cast({:suite_finished, 1, 2}, nil) == {:noreply, nil}
+      assert capture_io(fn ->
+               assert Formatter.handle_cast({:suite_finished, 1, 2}, nil) == {:noreply, nil}
+             end) =~ "Xcribe documentation written in"
+
       assert @output_path |> File.read!() |> String.replace(~r/\s/, "") == expected_content
     end
 
@@ -61,7 +64,10 @@ defmodule XcribeFormatterTest do
 
       expected_content = @sample_requests_as_string
 
-      assert Formatter.handle_cast({:suite_finished, 1, 2}, nil) == {:noreply, nil}
+      assert capture_io(fn ->
+               assert Formatter.handle_cast({:suite_finished, 1, 2}, nil) == {:noreply, nil}
+             end) =~ "Xcribe documentation written in"
+
       assert File.read!(@output_path) == expected_content
     end
   end

--- a/test/lib/formatter_test.exs
+++ b/test/lib/formatter_test.exs
@@ -93,10 +93,6 @@ defmodule XcribeFormatterTest do
     end
 
     test "handle invalid configuration" do
-      # Deprecated config keys
-      Application.delete_env(:xcribe, :output_file)
-      Application.delete_env(:xcribe, :doc_format)
-
       Application.put_env(:xcribe, :format, :invalid)
       Application.put_env(:xcribe, :json_library, Fake)
       Application.put_env(:xcribe, :information_source, Fake)


### PR DESCRIPTION
There is no benefits in keeping old configurations keys, and its often generate false negative in CI tests.