### PR TITLE
Fix path in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,9 @@ Improve CI/CD flow:
 - Add changelog and Makefile.
 
 [unreleased]: https://github.com/brainn-co/xcribe/compa...master
-[0.7.1]: https://github.com/brainn-co/xcribe/compare/0.7.0...0.7.1
-[0.7.0]: https://github.com/brainn-co/xcribe/compare/0.6.1...0.7.0
-[0.6.1]: https://github.com/brainn-co/xcribe/compare/0.6.0...0.6.1
+[0.7.1]: https://github.com/brainn-co/xcribe/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/brainn-co/xcribe/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/brainn-co/xcribe/compare/0.6.0...v0.6.1
 [0.6.0]: https://github.com/brainn-co/xcribe/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/brainn-co/xcribe/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/brainn-co/xcribe/compare/0.3.0...0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2020-06-09
+
+### Fixed
+
+- Relative path format on errors.
+- Changelog links.
+
 ## [0.7.1] - 2020-06-09
+
+### Enhancements
 
 - Improve internal modules naming and location.
 
@@ -67,7 +76,8 @@ Improve CI/CD flow:
 - New "tags" parameter to operations object in Swagger format.
 - Add changelog and Makefile.
 
-[unreleased]: https://github.com/brainn-co/xcribe/compa...master
+[unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.2...master
+[0.7.2]: https://github.com/brainn-co/xcribe/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/brainn-co/xcribe/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/brainn-co/xcribe/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/brainn-co/xcribe/compare/0.6.0...v0.6.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.7.1"}
+    {:xcribe, "~> 0.7.2"}
   ]
 end
 ```

--- a/lib/xcribe/cli/output.ex
+++ b/lib/xcribe/cli/output.ex
@@ -94,7 +94,7 @@ defmodule Xcribe.CLI.Output do
     """)
   end
 
-  defp format_file_path(path), do: String.replace(path, File.cwd!(), "")
+  defp format_file_path(path), do: Path.relative_to_cwd(path)
 
   defp tab(color), do: "#{color}┃#{@reset}"
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.7.1"
+  @version "0.7.2"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/brainn-co/xcribe"}
 

--- a/test/xcribe/cli/output_test.exs
+++ b/test/xcribe/cli/output_test.exs
@@ -42,7 +42,7 @@ defmodule Xcribe.CLI.OutputTest do
       \e[44m\e[37m  [ Xcribe ] Parsing Errors                                                                      \e[0m
       \e[34m┃\e[0m
       \e[34m┃\e[0m [P] → \e[33m route not found
-      \e[34m┃\e[0m        \e[34m> test name\n\e[34m┃\e[0m        \e[38;5;240m/test/xcribe/cli/output_test.exs:13
+      \e[34m┃\e[0m        \e[34m> test name\n\e[34m┃\e[0m        \e[38;5;240mtest/xcribe/cli/output_test.exs:13
       \e[38;5;25m┃\e[0m
       \e[38;5;25m┃\e[0m        \e[38;5;37m# |> document(as: "some cool description")
       \e[38;5;25m┃\e[0m        \e[38;5;25m     ^^^^^^^^                             
@@ -51,7 +51,7 @@ defmodule Xcribe.CLI.OutputTest do
       \e[34m┃\e[0m
       \e[34m┃\e[0m [P] → \e[33m invalid Router or invalid Conn
       \e[34m┃\e[0m        \e[34m> conn test
-      \e[34m┃\e[0m        \e[38;5;240m/test/xcribe/cli/output_test.exs:27
+      \e[34m┃\e[0m        \e[38;5;240mtest/xcribe/cli/output_test.exs:27
       \e[38;5;25m┃\e[0m
       \e[38;5;25m┃\e[0m        \e[38;5;37m# |> document(as: \"awesome route\")
       \e[38;5;25m┃\e[0m        \e[38;5;25m     ^^^^^^^^                     
@@ -168,7 +168,7 @@ defmodule Xcribe.CLI.OutputTest do
       \e[31m┃\e[0m
       \e[31m┃\e[0m [E] → \e[31m An exception was raised. Elixir.FunctionClauseError
       \e[31m┃\e[0m        \e[34m> conn test
-      \e[31m┃\e[0m        \e[38;5;240m/test/xcribe/cli/output_test.exs:27
+      \e[31m┃\e[0m        \e[38;5;240mtest/xcribe/cli/output_test.exs:27
       \e[38;5;88m┃\e[0m
       \e[38;5;88m┃\e[0m        \e[38;5;37m# |> document(as: \"awesome route\")
       \e[38;5;88m┃\e[0m        \e[38;5;88m     ^^^^^^^^                     


### PR DESCRIPTION
## Motivation

The path in the error including the leading slash in the path. This is different than normally the elixir tools format relative paths. And also may make more difficult to copy the path into an editor.

Example:
![Screenshot at 2020-07-09 17-59-12](https://user-images.githubusercontent.com/13632762/87090677-b9c13880-c20e-11ea-8e3e-2648e7a489f1.png)


## Proposed solution

Use https://hexdocs.pm/elixir/Path.html#relative_to_cwd/1

Before:

![Screenshot at 2020-07-09 18-02-23](https://user-images.githubusercontent.com/13632762/87090695-bf1e8300-c20e-11ea-8bee-3847bddc5804.png)

After:

![Screenshot at 2020-07-09 18-03-23](https://user-images.githubusercontent.com/13632762/87090716-c80f5480-c20e-11ea-8510-40464b410fae.png)


