### PR TITLE
Translate structs to maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse DateTimes and other stringifiable structs as strings at request params.
 - Treat structs as maps at request params.
 
-## [0.7.2] - 2020-06-11
+## [0.7.3] - 2020-06-11
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parse DateTimes and other stringifiable structs as strings at request params.
+- Treat structs as maps at request params.
+
 ## [0.7.2] - 2020-06-11
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2020-09-25
+
 ### Fixed
 
 - Parse DateTimes and other stringifiable structs as strings at request params.
@@ -91,6 +93,7 @@ Improve CI/CD flow:
 - Add changelog and Makefile.
 
 [unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.3...master
+[0.7.4]: https://github.com/brainn-co/xcribe/compare/0.7.3...0.7.4
 [0.7.3]: https://github.com/brainn-co/xcribe/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/brainn-co/xcribe/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/brainn-co/xcribe/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.7.3"}
+    {:xcribe, "~> 0.7.4"}
   ]
 end
 ```

--- a/lib/xcribe/json_schema.ex
+++ b/lib/xcribe/json_schema.ex
@@ -103,13 +103,10 @@ defmodule Xcribe.JsonSchema do
     )
   end
 
-  defp stringy?(%{__struct__: module}) when is_atom(module) do
-    try do
-      Protocol.assert_impl!(String.Chars, module)
-      true
-    rescue
-      Protocol.UndefinedError -> false
-      ArgumentError -> false
+  defp stringy?(value) do
+    case String.Chars.impl_for(value) do
+      nil -> false
+      _ -> true
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.7.3"
+  @version "0.7.4"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/brainn-co/xcribe"}
 

--- a/test/xcribe/json_schema_test.exs
+++ b/test/xcribe/json_schema_test.exs
@@ -156,5 +156,60 @@ defmodule Xcribe.JsonSchemaTest do
                }
              }
     end
+
+    test "schema for stringifiable struct" do
+      value = ~D[2020-04-23]
+      map = %{"last_login" => value}
+
+      assert JsonSchema.schema_for(map) == %{
+               type: "object",
+               properties: %{
+                 "last_login" => %{type: "string", example: to_string(value)}
+               }
+             }
+    end
+
+    test "schema for map with nested struct that is stringifiable" do
+      value = ~D[2020-04-23]
+      map = %{"authentication" => %{"last_login" => value}, "name" => "some name"}
+
+      assert JsonSchema.schema_for(map) == %{
+               type: "object",
+               properties: %{
+                 "authentication" => %{
+                   type: "object",
+                   properties: %{"last_login" => %{type: "string", example: to_string(value)}}
+                 },
+                 "name" => %{type: "string", example: "some name"}
+               }
+             }
+    end
+
+    defmodule NonStringifiablePerson do
+      defstruct [:name, :age]
+    end
+
+    test "schema for a struct that is not stringifiable" do
+      value = %NonStringifiablePerson{name: "some name", age: 18}
+      map = %{"profile" => %{"person" => value}}
+
+      assert JsonSchema.schema_for(map) == %{
+               type: "object",
+               properties: %{
+                 "profile" => %{
+                   type: "object",
+                   properties: %{
+                     "person" => %{
+                       type: "object",
+                       properties: %{
+                         age: %{example: 18, format: "int32", type: "number"},
+                         name: %{example: "some name", type: "string"}
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+    end
   end
 end


### PR DESCRIPTION
## Motivation

This PR is an attempt to fix xcribe issues with structs:
- #28: Xcribe breaks when Date struct is given as params
- #49: Support Plug.Upload struct

## Proposed solution

1. When a struct implements the protocol `String.Chars`, apply `to_string/1`. ~This implementation check is done using `Protocol.assert_impl!/2` with a try/catch block (`assert_impl?` does not exist :cry: ).~ This implementation check is done using `String.Chars.impl_for/1`.
2. When a struct doesn't implement `String.Chars` , apply `Map.from_struct/1` to it and remove struct metadata.
