### PR TITLE
Add Phoenix as dependence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2020-11-14
+
+### Fixed
+
+- Compilation warning about Phoenix module.
+
 ## [0.7.5] - 2020-11-13
 
 ### Fixed
@@ -95,7 +101,8 @@ Improve CI/CD flow:
 - New "tags" parameter to operations object in Swagger format.
 - Add changelog and Makefile.
 
-[unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.5...master
+[unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.6...master
+[0.7.6]: https://github.com/brainn-co/xcribe/compare/v0.7.5...v0.7.6
 [0.7.5]: https://github.com/brainn-co/xcribe/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/brainn-co/xcribe/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/brainn-co/xcribe/compare/v0.7.2...v0.7.3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.7.5"}
+    {:xcribe, "~> 0.7.6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.7.5"
+  @version "0.7.6"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/brainn-co/xcribe"}
 

--- a/mix.exs
+++ b/mix.exs
@@ -43,6 +43,8 @@ defmodule Xcribe.MixProject do
 
   defp deps do
     [
+      {:phoenix, "~> 1.4"},
+
       # Dev environment
       {:earmark, "~> 1.2", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev},
@@ -51,7 +53,6 @@ defmodule Xcribe.MixProject do
       # Test environment
       {:floki, "~> 0.26", only: [:test]},
       {:jason, "~> 1.1", only: [:dev, :test]},
-      {:phoenix, "~> 1.4.10", only: [:test]},
       {:excoveralls, "~> 0.13", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo_naming, "~> 0.5", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
## Motivation

issue #40 

## Proposed solution
Add `Phoenix` as a `Xcribe` dependence will make Elixir complies `Phoenix` before `Xcribe`.
