### PR TITLE
Fix#28/handle structs as params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2020-11-27
+
+### Fixed
+
+- Validate requests and report an error message when found structs in HTTP params
+
 ## [0.7.6] - 2020-11-14
 
 ### Fixed
@@ -101,7 +107,8 @@ Improve CI/CD flow:
 - New "tags" parameter to operations object in Swagger format.
 - Add changelog and Makefile.
 
-[unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.6...master
+[unreleased]: https://github.com/brainn-co/xcribe/compare/v0.7.7...master
+[0.7.7]: https://github.com/brainn-co/xcribe/compare/v0.7.6...v0.7.7
 [0.7.6]: https://github.com/brainn-co/xcribe/compare/v0.7.5...v0.7.6
 [0.7.5]: https://github.com/brainn-co/xcribe/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/brainn-co/xcribe/compare/v0.7.3...v0.7.4

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mix.exs
 ```elixir
 def deps do
   [
-    {:xcribe, "~> 0.7.6"}
+    {:xcribe, "~> 0.7.7"}
   ]
 end
 ```

--- a/lib/xcribe/cli/output.ex
+++ b/lib/xcribe/cli/output.ex
@@ -21,13 +21,13 @@ defmodule Xcribe.CLI.Output do
   alias Xcribe.DocException
 
   def print_request_errors(errors) do
-    print_header_error("[ Xcribe ] Parsing Errors", @bg_blue)
+    print_header_error("[ Xcribe ] Parsing and validation errors", @bg_blue)
 
     Enum.each(errors, &print_error/1)
   end
 
   def print_configuration_errors(errors) do
-    print_header_error("[ Xcribe ] Configuration Errors", @bg_green)
+    print_header_error("[ Xcribe ] Configuration errors", @bg_green)
 
     Enum.each(errors, &print_error/1)
   end
@@ -57,12 +57,13 @@ defmodule Xcribe.CLI.Output do
     """)
   end
 
-  defp print_error(%{type: :parsing, message: msg, __meta__: %{call: call}}) do
+  defp print_error(%{type: typ, message: msg, __meta__: %{call: call}})
+       when typ in [:parsing, :validation] do
     line_call = get_line(call.file, call.line)
 
     IO.puts("""
     #{tab(@blue)}
-    #{tab(@blue)} [P] → #{@yellow} #{msg}
+    #{tab(@blue)} [#{error_char(typ)}] → #{@yellow} #{msg}
     #{tab(@blue)} #{space(6)} #{@blue}> #{call.description}
     #{tab(@blue)} #{space(6)} #{@gray}#{format_file_path(call.file)}:#{call.line}
     #{tab(@dark_blue)}
@@ -109,6 +110,9 @@ defmodule Xcribe.CLI.Output do
 
   defp space_for(message), do: String.duplicate(" ", @bar_size - String.length(message))
   defp space(count), do: String.duplicate(" ", count)
+
+  defp error_char(:parsing), do: "P"
+  defp error_char(:validation), do: "V"
 
   def get_line(filename, line) do
     filename

--- a/lib/xcribe/request/validator.ex
+++ b/lib/xcribe/request/validator.ex
@@ -23,7 +23,8 @@ defmodule Xcribe.Request.Validator do
   def find_struct(%{__struct__: module}) do
     %Error{
       type: :validation,
-      message: "The Plug.Conn params must be valid HTTP params. A struct #{module} was found!"
+      message:
+        "The Plug.Conn params must be valid HTTP params. A struct #{sanitize_module_name(module)} was found!"
     }
   end
 
@@ -41,6 +42,9 @@ defmodule Xcribe.Request.Validator do
       %Error{} = error -> {:halt, error}
     end
   end
+
+  defp sanitize_module_name(module),
+    do: module |> Atom.to_string() |> String.replace_prefix("Elixir.", "")
 
   defp handle_validate_params(:ok, request), do: {:ok, request}
   defp handle_validate_params(%Error{} = error, _request), do: {:error, error}

--- a/lib/xcribe/request/validator.ex
+++ b/lib/xcribe/request/validator.ex
@@ -1,0 +1,52 @@
+defmodule Xcribe.Request.Validator do
+  alias Xcribe.Request
+  alias Xcribe.Request.Error
+
+  def validate(%Request{} = request) do
+    {:ok, request}
+    |> validate_parameters_in(:request_body)
+    |> validate_parameters_in(:path_params)
+    |> validate_parameters_in(:header_params)
+    |> validate_parameters_in(:query_params)
+    |> handle_validate(request)
+  end
+
+  defp validate_parameters_in({:error, _err} = error, _key), do: error
+
+  defp validate_parameters_in({:ok, request}, key) do
+    request
+    |> Map.fetch!(key)
+    |> find_struct()
+    |> handle_validate_params(request)
+  end
+
+  def find_struct(%{__struct__: module}) do
+    %Error{
+      type: :validation,
+      message: "The Plug.Conn params must be valid HTTP params. A struct #{module} was found!"
+    }
+  end
+
+  def find_struct(%{} = map), do: Enum.reduce_while(map, :ok, &reduce_map/2)
+  def find_struct(list) when is_list(list), do: Enum.reduce_while(list, :ok, &reduce_list/2)
+  def find_struct(_), do: :ok
+
+  defp reduce_list(value, _acc), do: reduce_function(value)
+
+  defp reduce_map({_key, value}, _acc), do: reduce_function(value)
+
+  defp reduce_function(value) do
+    case find_struct(value) do
+      :ok -> {:cont, :ok}
+      %Error{} = error -> {:halt, error}
+    end
+  end
+
+  defp handle_validate_params(:ok, request), do: {:ok, request}
+  defp handle_validate_params(%Error{} = error, _request), do: {:error, error}
+
+  defp handle_validate({:ok, _req} = success, _request), do: success
+
+  defp handle_validate({:error, error}, request),
+    do: {:error, %{error | __meta__: request.__meta__}}
+end

--- a/lib/xcribe/request/validator.ex
+++ b/lib/xcribe/request/validator.ex
@@ -20,7 +20,7 @@ defmodule Xcribe.Request.Validator do
     |> handle_validate_params(request)
   end
 
-  def find_struct(%{__struct__: module}) do
+  defp find_struct(%{__struct__: module}) do
     %Error{
       type: :validation,
       message:
@@ -28,9 +28,9 @@ defmodule Xcribe.Request.Validator do
     }
   end
 
-  def find_struct(%{} = map), do: Enum.reduce_while(map, :ok, &reduce_map/2)
-  def find_struct(list) when is_list(list), do: Enum.reduce_while(list, :ok, &reduce_list/2)
-  def find_struct(_), do: :ok
+  defp find_struct(%{} = map), do: Enum.reduce_while(map, :ok, &reduce_map/2)
+  defp find_struct(list) when is_list(list), do: Enum.reduce_while(list, :ok, &reduce_list/2)
+  defp find_struct(_), do: :ok
 
   defp reduce_list(value, _acc), do: reduce_function(value)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Xcribe.MixProject do
   use Mix.Project
 
-  @version "0.7.6"
+  @version "0.7.7"
   @description "A lib to generate API documentation from test specs"
   @links %{"GitHub" => "https://github.com/brainn-co/xcribe"}
 

--- a/test/xcribe/cli/output_test.exs
+++ b/test/xcribe/cli/output_test.exs
@@ -39,7 +39,7 @@ defmodule Xcribe.CLI.OutputTest do
       }
 
       expected_output = """
-      \e[44m\e[37m  [ Xcribe ] Parsing Errors                                                                      \e[0m
+      \e[44m\e[37m  [ Xcribe ] Parsing and validation errors                                                       \e[0m
       \e[34m┃\e[0m
       \e[34m┃\e[0m [P] → \e[33m route not found
       \e[34m┃\e[0m        \e[34m> test name\n\e[34m┃\e[0m        \e[38;5;240mtest/xcribe/cli/output_test.exs:13
@@ -63,6 +63,39 @@ defmodule Xcribe.CLI.OutputTest do
                assert Output.print_request_errors([route_error, conn_error]) == :ok
              end) == expected_output
     end
+
+    test "printing request validation error" do
+      validation_error = %Error{
+        type: :validation,
+        message:
+          "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+        __meta__: %{
+          call: %{
+            description: "test name",
+            file: File.cwd!() <> "/test/xcribe/cli/output_test.exs",
+            line: 13
+          }
+        }
+      }
+
+      expected_output = """
+      \e[44m\e[37m  [ Xcribe ] Parsing and validation errors                                                       \e[0m
+      \e[34m┃\e[0m
+      \e[34m┃\e[0m [V] → \e[33m The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!
+      \e[34m┃\e[0m        \e[34m> test name
+      \e[34m┃\e[0m        \e[38;5;240mtest/xcribe/cli/output_test.exs:13
+      \e[38;5;25m┃\e[0m
+      \e[38;5;25m┃\e[0m        \e[38;5;37m# |> document(as: \"some cool description\")
+      \e[38;5;25m┃\e[0m        \e[38;5;25m     ^^^^^^^^                             
+      \e[38;5;25m┃\e[0m
+      \
+
+      """
+
+      assert capture_io(fn ->
+               assert Output.print_request_errors([validation_error]) == :ok
+             end) == expected_output
+    end
   end
 
   describe "print_configuration_errors/1" do
@@ -78,7 +111,7 @@ defmodule Xcribe.CLI.OutputTest do
       ]
 
       expected_output = """
-      \e[42m\e[37m  [ Xcribe ] Configuration Errors                                                                \e[0m
+      \e[42m\e[37m  [ Xcribe ] Configuration errors                                                                \e[0m
       \e[32m┃\e[0m
       \e[32m┃\e[0m [C] → \e[34m Given json library doesn't implement needed functions
       \e[32m┃\e[0m        \e[38;5;240m> Config key: json_library
@@ -118,7 +151,7 @@ defmodule Xcribe.CLI.OutputTest do
       ]
 
       expected_output = """
-      \e[42m\e[37m  [ Xcribe ] Configuration Errors                                                                \e[0m
+      \e[42m\e[37m  [ Xcribe ] Configuration errors                                                                \e[0m
       \e[32m┃\e[0m
       \e[32m┃\e[0m [C] → \e[34m When serve config is true you must confiture output to \"priv/static\" folder
       \e[38;5;100m┃\e[0m

--- a/test/xcribe/request/validator_test.exs
+++ b/test/xcribe/request/validator_test.exs
@@ -1,0 +1,126 @@
+defmodule Xcribe.Request.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias Xcribe.Request
+  alias Xcribe.Request.{Error, Validator}
+
+  describe "validate/1" do
+    test "return ok when request is valid" do
+      request = %Request{
+        action: "index",
+        controller: Elixir.Xcribe.UsersController,
+        description: "",
+        header_params: [{"authorization", "token"}],
+        params: %{},
+        path: "/users",
+        path_params: %{},
+        query_params: %{},
+        request_body: %{},
+        resource: "users",
+        resource_group: :api,
+        resp_body: "[{\"id\":1,\"name\":\"user 1\"},{\"id\":2,\"name\":\"user 2\"}]",
+        resp_headers: [
+          {"content-type", "application/json; charset=utf-8"},
+          {"cache-control", "max-age=0, private, must-revalidate"}
+        ],
+        status_code: 200,
+        verb: "get"
+      }
+
+      assert Validator.validate(request) == {:ok, request}
+    end
+
+    test "return an error when request has a struct in path_params" do
+      meta = %{metadata: "value"}
+      request = %Request{path_params: ~D[2021-02-15], __meta__: meta}
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Error{
+                  type: :validation,
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  __meta__: meta
+                }}
+    end
+
+    test "return an error when request has a struct in request_body" do
+      meta = %{metadata: "value"}
+      request = %Request{request_body: ~D[2021-02-15], __meta__: meta}
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Error{
+                  type: :validation,
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  __meta__: meta
+                }}
+    end
+
+    test "return an error when request has a struct in header_params" do
+      meta = %{metadata: "value"}
+      request = %Request{header_params: ~D[2021-02-15], __meta__: meta}
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Error{
+                  type: :validation,
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  __meta__: meta
+                }}
+    end
+
+    test "return an error when request has a struct in query_params" do
+      meta = %{metadata: "value"}
+      request = %Request{query_params: ~D[2021-02-15], __meta__: meta}
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Error{
+                  type: :validation,
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  __meta__: meta
+                }}
+    end
+
+    test "params with nested struct" do
+      request = %Request{
+        request_body: %{
+          date: ~D[2021-02-15]
+        }
+      }
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Xcribe.Request.Error{
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  type: :validation
+                }}
+    end
+
+    test "params with nested struct into list" do
+      request = %Request{
+        request_body: %{
+          params: [
+            1,
+            %{
+              date: ~D[2021-02-15]
+            }
+          ]
+        }
+      }
+
+      assert Validator.validate(request) ==
+               {:error,
+                %Xcribe.Request.Error{
+                  message:
+                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                  type: :validation
+                }}
+    end
+  end
+end

--- a/test/xcribe/request/validator_test.exs
+++ b/test/xcribe/request/validator_test.exs
@@ -39,7 +39,7 @@ defmodule Xcribe.Request.ValidatorTest do
                 %Error{
                   type: :validation,
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   __meta__: meta
                 }}
     end
@@ -53,7 +53,7 @@ defmodule Xcribe.Request.ValidatorTest do
                 %Error{
                   type: :validation,
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   __meta__: meta
                 }}
     end
@@ -67,7 +67,7 @@ defmodule Xcribe.Request.ValidatorTest do
                 %Error{
                   type: :validation,
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   __meta__: meta
                 }}
     end
@@ -81,7 +81,7 @@ defmodule Xcribe.Request.ValidatorTest do
                 %Error{
                   type: :validation,
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   __meta__: meta
                 }}
     end
@@ -97,7 +97,7 @@ defmodule Xcribe.Request.ValidatorTest do
                {:error,
                 %Xcribe.Request.Error{
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   type: :validation
                 }}
     end
@@ -118,7 +118,7 @@ defmodule Xcribe.Request.ValidatorTest do
                {:error,
                 %Xcribe.Request.Error{
                   message:
-                    "The Plug.Conn params must be valid HTTP params. A struct Elixir.Date was found!",
+                    "The Plug.Conn params must be valid HTTP params. A struct Date was found!",
                   type: :validation
                 }}
     end


### PR DESCRIPTION
## Motivation

Fix #28 

Solves #19 with another approach. Since we implemented #36, Xcribe handle some parsing errors. Now we have a general validator that meet the #19 proposal, that is validate requests before trying to write the doc.

## Proposed solution

- Create a module to validate the `Request` struct data.
- Ensure request params hasn't structs.
- Output an error message for requests with structs
![image](https://user-images.githubusercontent.com/17304947/100458642-df0df080-30a2-11eb-9620-78e2de492bea.png)

This solution was discussed in #51  
